### PR TITLE
Add frontend proxy API and compose env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Dumb Docker
+
+This repo contains a simple Next.js frontend with a backend container. The frontend proxies API
+requests to the backend using an internal environment variable.
+
+## Environment Variables
+
+- `BACKEND_URL` – address of the backend API. Defaults to `http://backend:8000` when not set.
+  `docker-compose.yml` sets this to the backend service so the frontend can access the API in
+  development.
+
+If you are running in GitHub Codespaces, ensure this variable is set in your devcontainer or compose
+configuration so the API proxy works correctly.
+
+## Development
+
+Run the application with Docker Compose:
+
+```bash
+docker-compose up
+```
+
+This starts the frontend on port `3000` and the backend on port `8000`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.9'
+services:
+  frontend:
+    image: node:18
+    working_dir: /app
+    volumes:
+      - ./frontend:/app
+    command: npm run dev
+    environment:
+      - BACKEND_URL=http://backend:8000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - backend
+  backend:
+    image: backend:latest
+    ports:
+      - "8000:8000"

--- a/frontend/pages/api/containers.js
+++ b/frontend/pages/api/containers.js
@@ -1,0 +1,17 @@
+export default async function handler(req, res) {
+  const backendUrl = process.env.BACKEND_URL || 'http://backend:8000';
+  try {
+    const response = await fetch(`${backendUrl}/api/containers`, {
+      method: req.method,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: req.method !== 'GET' ? JSON.stringify(req.body) : undefined,
+    });
+    const data = await response.json();
+    res.status(response.status).json(data);
+  } catch (err) {
+    console.error('Proxy error:', err);
+    res.status(500).json({ error: 'Failed to fetch containers' });
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export default function Home() {
+  const [containers, setContainers] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/containers')
+      .then((res) => res.json())
+      .then(setContainers)
+      .catch((err) => console.error('Failed to fetch containers', err));
+  }, []);
+
+  return (
+    <div>
+      <h1>Containers</h1>
+      <pre>{JSON.stringify(containers, null, 2)}</pre>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add simple Next.js frontend and proxy API route
- fetch containers from the proxy path
- configure docker-compose with BACKEND_URL for the frontend
- document env var and Codespaces usage

## Testing
- `docker-compose up` *(fails: backend image placeholder)*

------
https://chatgpt.com/codex/tasks/task_e_6844be875ccc832ca24ecb1bf20eed55