### PR TITLE
Add setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ requests to the backend using an internal environment variable.
 If you are running in GitHub Codespaces, ensure this variable is set in your devcontainer or compose
 configuration so the API proxy works correctly.
 
+## Setup
+
+Before starting the containers, install the frontend dependencies. The compose file mounts the source and runs `npm run dev`, so the packages must be installed locally first.
+
+```bash
+cd frontend && npm install
+```
+
 ## Development
 
 Run the application with Docker Compose. The first time you run it, include the


### PR DESCRIPTION
## Summary
- document the setup step for installing frontend dependencies
- clarify that Compose mounts the source and runs `npm run dev`

## Testing
- `npm install`
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6844cb74c5f0832caac947d36347d9bf