### PR TITLE
Add setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ requests to the backend using an internal environment variable.
 If you are running in GitHub Codespaces, ensure this variable is set in your devcontainer or compose
 configuration so the API proxy works correctly.
 
+## Setup
+
+Before starting the containers, install the frontend dependencies. The compose file mounts the source and runs `npm run dev`, so the packages must be installed. Docker Compose will install them automatically, but doing it manually first speeds up the initial boot.
+
+```bash
+cd frontend && npm install
+```
+
 ## Development
 
 Run the application with Docker Compose. The first time you run it, include the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     working_dir: /app
     volumes:
       - ./frontend:/app
-    command: npm run dev
+    command: sh -c "npm install && npm run dev"
     environment:
       - BACKEND_URL=http://backend:8000
     ports:


### PR DESCRIPTION
## Summary
- document the setup step for installing frontend dependencies
- clarify that Compose mounts the source and runs `npm run dev`
- ensure Compose installs dependencies on startup

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*


------
https://chatgpt.com/codex/tasks/task_e_6844cb74c5f0832caac947d36347d9bf