### PR TITLE
Update docs for BACKEND_URL and dev proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ proxies API requests to the backend so it can access the Docker data.
 ## Environment Variables
 - `FRONTEND_PORT` – host port to expose the frontend. Defaults to `3000`.
 - `BACKEND_PORT` – host port to expose the backend API. Defaults to `8000`.
+- `BACKEND_URL` – address of the backend API when running the frontend
+  outside Docker Compose.
 
 Create a `.env` file in the project root to override these ports:
 
@@ -40,3 +42,10 @@ docker-compose up --build
 
 This starts the frontend on the port defined in `FRONTEND_PORT` (default `3000`)
 and the FastAPI backend on the port defined in `BACKEND_PORT` (default `8000`).
+
+If you run the Next.js app without Docker Compose, set `BACKEND_URL` so the API
+routes know where to proxy requests, for example:
+
+```bash
+BACKEND_URL=http://localhost:8000 npm run dev
+```

--- a/frontend/pages/api/containers.js
+++ b/frontend/pages/api/containers.js
@@ -1,5 +1,9 @@
 export default async function handler(req, res) {
-  const backendUrl = process.env.BACKEND_URL || 'http://backend:8000';
+  const port = process.env.BACKEND_PORT || '8000';
+  const devUrl = `http://localhost:${port}`;
+  const backendUrl =
+    process.env.BACKEND_URL ||
+    (process.env.NODE_ENV === 'development' ? devUrl : 'http://backend:8000');
   try {
     const response = await fetch(`${backendUrl}/api/containers`, {
       method: req.method,

--- a/frontend/pages/api/containers/[id]/[action].js
+++ b/frontend/pages/api/containers/[id]/[action].js
@@ -1,6 +1,10 @@
 export default async function handler(req, res) {
   const { id, action } = req.query;
-  const backendUrl = process.env.BACKEND_URL || 'http://backend:8000';
+  const port = process.env.BACKEND_PORT || '8000';
+  const devUrl = `http://localhost:${port}`;
+  const backendUrl =
+    process.env.BACKEND_URL ||
+    (process.env.NODE_ENV === 'development' ? devUrl : 'http://backend:8000');
   const url = `${backendUrl}/api/containers/${id}/${action}`;
   try {
     const response = await fetch(url, { method: req.method });


### PR DESCRIPTION
## Summary
- document BACKEND_URL and how to run frontend without Compose
- auto-detect development mode in API routes when BACKEND_URL is unset

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451caa1310832cb2cfe475d0acaf16