### PR TITLE
Improve container action UX

### DIFF
--- a/frontend/pages/api/containers.js
+++ b/frontend/pages/api/containers.js
@@ -8,7 +8,13 @@ export default async function handler(req, res) {
       },
       body: req.method !== 'GET' ? JSON.stringify(req.body) : undefined,
     });
-    const data = await response.json();
+    const text = await response.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { error: text };
+    }
     res.status(response.status).json(data);
   } catch (err) {
     console.error('Proxy error:', err);

--- a/frontend/pages/api/containers/[id]/[action].js
+++ b/frontend/pages/api/containers/[id]/[action].js
@@ -4,7 +4,13 @@ export default async function handler(req, res) {
   const url = `${backendUrl}/api/containers/${id}/${action}`;
   try {
     const response = await fetch(url, { method: req.method });
-    const data = await response.json();
+    const text = await response.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { error: text };
+    }
     res.status(response.status).json(data);
   } catch (err) {
     console.error('Proxy error:', err);


### PR DESCRIPTION
## Summary
- show per-container loading and error states in the UI
- display backend error messages
- disable action buttons during requests
- propagate backend errors from Next.js API

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68451c63a8b0832c8b1c86f6c9a3ce92