### PR TITLE
Limit auth to credentials

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# Required for NextAuth
+NEXTAUTH_SECRET=changeme
+ADMIN_EMAIL=admin@example.com
+# bcrypt hash of your admin password
+ADMIN_PASSWORD_HASH=$2a$10$examplehash

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,6 @@
 # Required for NextAuth
 NEXTAUTH_SECRET=changeme
-ADMIN_USERNAME=admin
+# email for admin login
+ADMIN_EMAIL=admin@example.com
 # bcrypt hash of your admin password
 ADMIN_PASSWORD_HASH=$2a$10$examplehash

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,7 +2,7 @@
 NEXTAUTH_SECRET=changeme
 # username for admin login
 ADMIN_USERNAME=admin
-# bcrypt hash of your admin password
-ADMIN_PASSWORD_HASH=$2a$10$examplehash
+# SHA256 hash of your admin password
+ADMIN_PASSWORD_SHA256=sha256digest
 # Alternatively, provide a plain password for testing
 # ADMIN_PASSWORD=plainpassword

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,3 +4,5 @@ NEXTAUTH_SECRET=changeme
 ADMIN_USERNAME=admin
 # bcrypt hash of your admin password
 ADMIN_PASSWORD_HASH=$2a$10$examplehash
+# Alternatively, provide a plain password for testing
+# ADMIN_PASSWORD=plainpassword

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,5 @@
 # Required for NextAuth
 NEXTAUTH_SECRET=changeme
-ADMIN_EMAIL=admin@example.com
+ADMIN_USERNAME=admin
 # bcrypt hash of your admin password
 ADMIN_PASSWORD_HASH=$2a$10$examplehash

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,6 @@
 # Required for NextAuth
 NEXTAUTH_SECRET=changeme
-# email for admin login
-ADMIN_EMAIL=admin@example.com
+# username for admin login
+ADMIN_USERNAME=admin
 # bcrypt hash of your admin password
 ADMIN_PASSWORD_HASH=$2a$10$examplehash

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,5 @@
 # Required for NextAuth
 NEXTAUTH_SECRET=changeme
-ADMIN_USERNAME=admin
+ADMIN_EMAIL=admin@example.com
 # bcrypt hash of your admin password
 ADMIN_PASSWORD_HASH=$2a$10$examplehash

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,7 +6,7 @@ This is a minimal Next.js frontend that displays Docker containers using React F
 
 The frontend uses [NextAuth.js](https://next-auth.js.org) with a Credentials provider.
 Configure the required environment variables in `.env` (see `.env.example`).
-Set `ADMIN_EMAIL` and a bcrypt hashed `ADMIN_PASSWORD_HASH` for the admin login.
+Set `ADMIN_USERNAME` and a bcrypt hashed `ADMIN_PASSWORD_HASH` for the admin login.
 Unauthenticated users will be redirected to `/login`.
 
 Run development server:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,7 +6,7 @@ This is a minimal Next.js frontend that displays Docker containers using React F
 
 The frontend uses [NextAuth.js](https://next-auth.js.org) with a Credentials provider.
 Configure the required environment variables in `.env` (see `.env.example`).
-Set `ADMIN_USERNAME` and a bcrypt hashed `ADMIN_PASSWORD_HASH` for the admin login.
+Set `ADMIN_EMAIL` and a bcrypt hashed `ADMIN_PASSWORD_HASH` for the admin login.
 Unauthenticated users will be redirected to `/login`.
 
 Run development server:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,7 +6,8 @@ This is a minimal Next.js frontend that displays Docker containers using React F
 
 The frontend uses [NextAuth.js](https://next-auth.js.org) with a Credentials provider.
 Configure the required environment variables in `.env` (see `.env.example`).
-Set `ADMIN_EMAIL` and a bcrypt hashed `ADMIN_PASSWORD_HASH` for the admin login.
+Set `ADMIN_USERNAME` and a bcrypt hashed `ADMIN_PASSWORD_HASH` for the admin login.
+`NEXTAUTH_SECRET` is a random string used by NextAuth to sign session tokens.
 Unauthenticated users will be redirected to `/login`.
 
 Run development server:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,7 +6,8 @@ This is a minimal Next.js frontend that displays Docker containers using React F
 
 The frontend uses [NextAuth.js](https://next-auth.js.org) with a Credentials provider.
 Configure the required environment variables in `.env` (see `.env.example`).
-Set `ADMIN_USERNAME` and a bcrypt hashed `ADMIN_PASSWORD_HASH` for the admin login.
+Set `ADMIN_USERNAME` and either a bcrypt hashed `ADMIN_PASSWORD_HASH` or a plain
+`ADMIN_PASSWORD` for the admin login.
 `NEXTAUTH_SECRET` is a random string used by NextAuth to sign session tokens.
 Unauthenticated users will be redirected to `/login`.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,8 +6,9 @@ This is a minimal Next.js frontend that displays Docker containers using React F
 
 The frontend uses [NextAuth.js](https://next-auth.js.org) with a Credentials provider.
 Configure the required environment variables in `.env` (see `.env.example`).
-Set `ADMIN_USERNAME` and either a bcrypt hashed `ADMIN_PASSWORD_HASH` or a plain
-`ADMIN_PASSWORD` for the admin login.
+Set `ADMIN_USERNAME` and either a SHA256 hashed `ADMIN_PASSWORD_SHA256` or a
+plain `ADMIN_PASSWORD` for the admin login. You can generate the SHA256 digest
+with any online converter.
 `NEXTAUTH_SECRET` is a random string used by NextAuth to sign session tokens.
 Unauthenticated users will be redirected to `/login`.
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,6 +6,7 @@ This is a minimal Next.js frontend that displays Docker containers using React F
 
 The frontend uses [NextAuth.js](https://next-auth.js.org) with a Credentials provider.
 Configure the required environment variables in `.env` (see `.env.example`).
+Set `ADMIN_EMAIL` and a bcrypt hashed `ADMIN_PASSWORD_HASH` for the admin login.
 Unauthenticated users will be redirected to `/login`.
 
 Run development server:
@@ -19,4 +20,3 @@ First install dependencies with:
 ```bash
 npm install
 ```
-

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -2,6 +2,12 @@
 
 This is a minimal Next.js frontend that displays Docker containers using React Flow.
 
+## Authentication
+
+The frontend uses [NextAuth.js](https://next-auth.js.org) with a Credentials provider.
+Configure the required environment variables in `.env` (see `.env.example`).
+Unauthenticated users will be redirected to `/login`.
+
 Run development server:
 
 ```bash

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,16 +9,18 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "next": "15.3.3",
+    "next-auth": "^4.24.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.3",
     "reactflow": "^11.11.4"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.3",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4"
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "bcryptjs": "^2.4.3",
     "next": "15.3.3",
     "next-auth": "^4.24.6",
     "react": "^19.0.0",

--- a/frontend/pages/api/auth/[...nextauth].js
+++ b/frontend/pages/api/auth/[...nextauth].js
@@ -13,11 +13,17 @@ export const authOptions = {
       async authorize(credentials) {
         const adminUsername = process.env.ADMIN_USERNAME;
         const adminHash = process.env.ADMIN_PASSWORD_HASH;
+        const adminPassword = process.env.ADMIN_PASSWORD;
         if (!credentials?.username || !credentials.password) return null;
         if (credentials.username !== adminUsername) return null;
-        if (!adminHash) return null;
-        const ok = await bcrypt.compare(credentials.password, adminHash);
-        if (!ok) return null;
+        if (adminHash) {
+          const ok = await bcrypt.compare(credentials.password, adminHash);
+          if (!ok) return null;
+        } else if (adminPassword) {
+          if (credentials.password !== adminPassword) return null;
+        } else {
+          return null;
+        }
         return { id: 'admin', name: adminUsername };
       },
     }),

--- a/frontend/pages/api/auth/[...nextauth].js
+++ b/frontend/pages/api/auth/[...nextauth].js
@@ -7,18 +7,18 @@ export const authOptions = {
     CredentialsProvider({
       name: 'Credentials',
       credentials: {
-        email: { label: 'Email', type: 'email', placeholder: 'admin@example.com' },
+        username: { label: 'Username', type: 'text', placeholder: 'admin' },
         password: { label: 'Password', type: 'password' },
       },
       async authorize(credentials) {
-        const adminEmail = process.env.ADMIN_EMAIL;
+        const adminUser = process.env.ADMIN_USERNAME;
         const adminHash = process.env.ADMIN_PASSWORD_HASH;
-        if (!credentials?.email || !credentials.password) return null;
-        if (credentials.email !== adminEmail) return null;
+        if (!credentials?.username || !credentials.password) return null;
+        if (credentials.username !== adminUser) return null;
         if (!adminHash) return null;
         const ok = await bcrypt.compare(credentials.password, adminHash);
         if (!ok) return null;
-        return { id: 'admin', email: adminEmail };
+        return { id: 'admin', name: adminUser };
       },
     }),
   ],

--- a/frontend/pages/api/auth/[...nextauth].js
+++ b/frontend/pages/api/auth/[...nextauth].js
@@ -1,0 +1,29 @@
+import NextAuth from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import bcrypt from 'bcryptjs';
+
+export const authOptions = {
+  providers: [
+    CredentialsProvider({
+      name: 'Credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email', placeholder: 'admin@example.com' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        const adminEmail = process.env.ADMIN_EMAIL;
+        const adminHash = process.env.ADMIN_PASSWORD_HASH;
+        if (!credentials?.email || !credentials.password) return null;
+        if (credentials.email !== adminEmail) return null;
+        if (!adminHash) return null;
+        const ok = await bcrypt.compare(credentials.password, adminHash);
+        if (!ok) return null;
+        return { id: 'admin', email: adminEmail };
+      },
+    }),
+  ],
+  session: { strategy: 'jwt' },
+  secret: process.env.NEXTAUTH_SECRET,
+};
+
+export default NextAuth(authOptions);

--- a/frontend/pages/api/auth/[...nextauth].js
+++ b/frontend/pages/api/auth/[...nextauth].js
@@ -7,18 +7,18 @@ export const authOptions = {
     CredentialsProvider({
       name: 'Credentials',
       credentials: {
-        username: { label: 'Username', type: 'text', placeholder: 'admin' },
+        email: { label: 'Email', type: 'email', placeholder: 'admin@example.com' },
         password: { label: 'Password', type: 'password' },
       },
       async authorize(credentials) {
-        const adminUsername = process.env.ADMIN_USERNAME;
+        const adminEmail = process.env.ADMIN_EMAIL;
         const adminHash = process.env.ADMIN_PASSWORD_HASH;
-        if (!credentials?.username || !credentials.password) return null;
-        if (credentials.username !== adminUsername) return null;
+        if (!credentials?.email || !credentials.password) return null;
+        if (credentials.email !== adminEmail) return null;
         if (!adminHash) return null;
         const ok = await bcrypt.compare(credentials.password, adminHash);
         if (!ok) return null;
-        return { id: 'admin', name: adminUsername };
+        return { id: 'admin', email: adminEmail };
       },
     }),
   ],

--- a/frontend/pages/api/auth/[...nextauth].js
+++ b/frontend/pages/api/auth/[...nextauth].js
@@ -7,23 +7,27 @@ export const authOptions = {
     CredentialsProvider({
       name: 'Credentials',
       credentials: {
-        username: { label: 'Username', type: 'text', placeholder: 'admin' },
+        email: { label: 'Email', type: 'text', placeholder: 'admin@example.com' },
         password: { label: 'Password', type: 'password' },
       },
       async authorize(credentials) {
-        const adminUser = process.env.ADMIN_USERNAME;
+        const adminEmail = process.env.ADMIN_EMAIL;
         const adminHash = process.env.ADMIN_PASSWORD_HASH;
-        if (!credentials?.username || !credentials.password) return null;
-        if (credentials.username !== adminUser) return null;
+        if (!credentials?.email || !credentials.password) return null;
+        if (credentials.email !== adminEmail) return null;
         if (!adminHash) return null;
         const ok = await bcrypt.compare(credentials.password, adminHash);
         if (!ok) return null;
-        return { id: 'admin', name: adminUser };
+        return { id: 'admin', email: adminEmail };
       },
     }),
   ],
   session: { strategy: 'jwt' },
   secret: process.env.NEXTAUTH_SECRET,
+  pages: {
+    signIn: '/login',
+    error: '/login',
+  },
 };
 
 export default NextAuth(authOptions);

--- a/frontend/pages/api/auth/[...nextauth].js
+++ b/frontend/pages/api/auth/[...nextauth].js
@@ -7,18 +7,18 @@ export const authOptions = {
     CredentialsProvider({
       name: 'Credentials',
       credentials: {
-        email: { label: 'Email', type: 'email', placeholder: 'admin@example.com' },
+        username: { label: 'Username', type: 'text', placeholder: 'admin' },
         password: { label: 'Password', type: 'password' },
       },
       async authorize(credentials) {
-        const adminEmail = process.env.ADMIN_EMAIL;
+        const adminUsername = process.env.ADMIN_USERNAME;
         const adminHash = process.env.ADMIN_PASSWORD_HASH;
-        if (!credentials?.email || !credentials.password) return null;
-        if (credentials.email !== adminEmail) return null;
+        if (!credentials?.username || !credentials.password) return null;
+        if (credentials.username !== adminUsername) return null;
         if (!adminHash) return null;
         const ok = await bcrypt.compare(credentials.password, adminHash);
         if (!ok) return null;
-        return { id: 'admin', email: adminEmail };
+        return { id: 'admin', name: adminUsername };
       },
     }),
   ],

--- a/frontend/pages/api/auth/[...nextauth].js
+++ b/frontend/pages/api/auth/[...nextauth].js
@@ -7,18 +7,18 @@ export const authOptions = {
     CredentialsProvider({
       name: 'Credentials',
       credentials: {
-        email: { label: 'Email', type: 'text', placeholder: 'admin@example.com' },
+        username: { label: 'Username', type: 'text', placeholder: 'admin' },
         password: { label: 'Password', type: 'password' },
       },
       async authorize(credentials) {
-        const adminEmail = process.env.ADMIN_EMAIL;
+        const adminUsername = process.env.ADMIN_USERNAME;
         const adminHash = process.env.ADMIN_PASSWORD_HASH;
-        if (!credentials?.email || !credentials.password) return null;
-        if (credentials.email !== adminEmail) return null;
+        if (!credentials?.username || !credentials.password) return null;
+        if (credentials.username !== adminUsername) return null;
         if (!adminHash) return null;
         const ok = await bcrypt.compare(credentials.password, adminHash);
         if (!ok) return null;
-        return { id: 'admin', email: adminEmail };
+        return { id: 'admin', name: adminUsername };
       },
     }),
   ],

--- a/frontend/pages/api/containers.js
+++ b/frontend/pages/api/containers.js
@@ -1,6 +1,12 @@
 import fs from 'fs';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from './auth/[...nextauth]';
 
 export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
   const port = process.env.BACKEND_PORT || '8000';
   const devUrl = `http://localhost:${port}`;
   const inDocker = fs.existsSync('/.dockerenv');

--- a/frontend/pages/api/containers/[id]/[action].js
+++ b/frontend/pages/api/containers/[id]/[action].js
@@ -1,6 +1,12 @@
 import fs from 'fs';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]';
 
 export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
   const { id, action } = req.query;
   const port = process.env.BACKEND_PORT || '8000';
   const devUrl = `http://localhost:${port}`;

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,3 +1,4 @@
+import { getSession } from "next-auth/react";
 import { useEffect, useState, useCallback } from 'react';
 import ReactFlow, { Background } from 'reactflow';
 import 'reactflow/dist/style.css';
@@ -164,4 +165,14 @@ export default function Home() {
       </ReactFlow>
     </div>
   );
+}
+
+export async function getServerSideProps(context) {
+  const session = await getSession(context);
+  if (!session) {
+    return {
+      redirect: { destination: '/login', permanent: false },
+    };
+  }
+  return { props: {} };
 }

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -10,7 +10,7 @@ export async function getServerSideProps(context) {
 }
 
 export default function Login() {
-  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState(null);
 
@@ -18,11 +18,11 @@ export default function Login() {
     e.preventDefault();
     const res = await signIn('credentials', {
       redirect: false,
-      email,
+      username,
       password,
     });
     if (res?.error) {
-      setError('Invalid email or password');
+      setError('Invalid username or password');
     } else {
       window.location.href = '/';
     }
@@ -32,13 +32,13 @@ export default function Login() {
     <div className="flex items-center justify-center h-screen">
       <form onSubmit={handleSubmit} className="bg-white p-4 shadow rounded flex flex-col gap-2 w-64">
         <label className="flex flex-col text-sm text-black">
-          Email
+          Username
           <input
-            name="email"
-            type="email"
+            name="username"
+            type="text"
             className="border rounded p-1 text-black"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
           />
         </label>
         <label className="flex flex-col text-sm text-black">

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -2,22 +2,25 @@ import { getCsrfToken } from 'next-auth/react';
 
 export async function getServerSideProps(context) {
   const csrfToken = await getCsrfToken(context);
-  return { props: { csrfToken } };
+  const { error } = context.query;
+  return { props: { csrfToken, error: error ?? null } };
 }
 
-export default function Login({ csrfToken }) {
+export default function Login({ csrfToken, error }) {
+  const errorMessage = error ? 'Invalid email or password' : null;
   return (
     <div className="flex items-center justify-center h-screen">
       <form method="post" action="/api/auth/callback/credentials" className="bg-white p-4 shadow rounded flex flex-col gap-2 w-64">
         <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
         <label className="flex flex-col text-sm text-black">
-          Username
-          <input name="username" type="text" className="border rounded p-1 text-black" />
+          Email
+          <input name="email" type="text" className="border rounded p-1 text-black" />
         </label>
         <label className="flex flex-col text-sm text-black">
           Password
           <input name="password" type="password" className="border rounded p-1 text-black" />
         </label>
+        {errorMessage && <p className="text-red-500 text-sm">{errorMessage}</p>}
         <button type="submit" className="bg-blue-500 text-white rounded p-1 mt-2">Sign in</button>
       </form>
     </div>

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -7,14 +7,14 @@ export async function getServerSideProps(context) {
 }
 
 export default function Login({ csrfToken, error }) {
-  const errorMessage = error ? 'Invalid email or password' : null;
+  const errorMessage = error ? 'Invalid username or password' : null;
   return (
     <div className="flex items-center justify-center h-screen">
       <form method="post" action="/api/auth/callback/credentials" className="bg-white p-4 shadow rounded flex flex-col gap-2 w-64">
         <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
         <label className="flex flex-col text-sm text-black">
-          Email
-          <input name="email" type="text" className="border rounded p-1 text-black" />
+          Username
+          <input name="username" type="text" className="border rounded p-1 text-black" />
         </label>
         <label className="flex flex-col text-sm text-black">
           Password

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -10,13 +10,13 @@ export default function Login({ csrfToken }) {
     <div className="flex items-center justify-center h-screen">
       <form method="post" action="/api/auth/callback/credentials" className="bg-white p-4 shadow rounded flex flex-col gap-2 w-64">
         <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
-        <label className="flex flex-col text-sm">
-          Email
-          <input name="email" type="email" className="border rounded p-1" />
+        <label className="flex flex-col text-sm text-black">
+          Username
+          <input name="username" type="text" className="border rounded p-1 text-black" />
         </label>
-        <label className="flex flex-col text-sm">
+        <label className="flex flex-col text-sm text-black">
           Password
-          <input name="password" type="password" className="border rounded p-1" />
+          <input name="password" type="password" className="border rounded p-1 text-black" />
         </label>
         <button type="submit" className="bg-blue-500 text-white rounded p-1 mt-2">Sign in</button>
       </form>

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -1,0 +1,25 @@
+import { getCsrfToken } from 'next-auth/react';
+
+export async function getServerSideProps(context) {
+  const csrfToken = await getCsrfToken(context);
+  return { props: { csrfToken } };
+}
+
+export default function Login({ csrfToken }) {
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <form method="post" action="/api/auth/callback/credentials" className="bg-white p-4 shadow rounded flex flex-col gap-2 w-64">
+        <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
+        <label className="flex flex-col text-sm">
+          Email
+          <input name="email" type="email" className="border rounded p-1" />
+        </label>
+        <label className="flex flex-col text-sm">
+          Password
+          <input name="password" type="password" className="border rounded p-1" />
+        </label>
+        <button type="submit" className="bg-blue-500 text-white rounded p-1 mt-2">Sign in</button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/pages/login.js
+++ b/frontend/pages/login.js
@@ -7,14 +7,14 @@ export async function getServerSideProps(context) {
 }
 
 export default function Login({ csrfToken, error }) {
-  const errorMessage = error ? 'Invalid username or password' : null;
+  const errorMessage = error ? 'Invalid email or password' : null;
   return (
     <div className="flex items-center justify-center h-screen">
       <form method="post" action="/api/auth/callback/credentials" className="bg-white p-4 shadow rounded flex flex-col gap-2 w-64">
         <input name="csrfToken" type="hidden" defaultValue={csrfToken} />
         <label className="flex flex-col text-sm text-black">
-          Username
-          <input name="username" type="text" className="border rounded p-1 text-black" />
+          Email
+          <input name="email" type="email" className="border rounded p-1 text-black" />
         </label>
         <label className="flex flex-col text-sm text-black">
           Password


### PR DESCRIPTION
## Summary
- restrict login to the admin credentials
- remove Google sign-in button
- simplify example `.env` and docs

## Testing
- `npm --prefix frontend run build` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b98772c0832cab5fc8d6ee5cf29b