### PR TITLE
Improve container card layout

### DIFF
--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -25,3 +25,8 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+
+.react-flow__node {
+  cursor: default !important;
+}


### PR DESCRIPTION
## Summary
- arrange docker container nodes horizontally by project
- disable node dragging and show default cursor

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684df9d62260832c97e781be3d41050c