### PR TITLE
Expose container ports in UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,21 +18,29 @@ def get_containers():
     result = []
     for c in containers:
         ports = []
+        port_map = {}
         network_ports = c.attrs.get("NetworkSettings", {}).get("Ports") or {}
         for container_port, bindings in network_ports.items():
             if not bindings:
                 continue
             for binding in bindings:
                 host_port = binding.get("HostPort")
+                if not host_port:
+                    continue
                 host_ip = binding.get("HostIp")
-                if host_port:
-                    ports.append(
-                        {
-                            "host_port": host_port,
-                            "container_port": container_port,
-                            "host_ip": host_ip,
-                        }
-                    )
+                key = (container_port, host_port)
+                existing = port_map.get(key)
+                prefers_current = existing and existing.get("host_ip") not in (None, "", "::")
+                prefers_new = host_ip not in (None, "", "::")
+                if existing and (prefers_current or not prefers_new):
+                    continue
+                port_map[key] = {
+                    "host_port": host_port,
+                    "container_port": container_port,
+                    "host_ip": host_ip,
+                }
+        if port_map:
+            ports = list(port_map.values())
         result.append({
             "id": c.id,
             "name": c.name,

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -104,6 +104,17 @@ function ContainerNode({ data }) {
   );
 }
 
+const BASE_NODE_HEIGHT = 240;
+const PORT_LINE_HEIGHT = 18;
+const PORT_SECTION_PADDING = 12;
+const ROW_VERTICAL_GAP = 40;
+
+function estimateNodeHeight(container) {
+  const portCount = container?.ports?.length || 0;
+  const portsHeight = portCount > 0 ? portCount * PORT_LINE_HEIGHT + PORT_SECTION_PADDING : 0;
+  return BASE_NODE_HEIGHT + portsHeight;
+}
+
 export default function Home() {
   const [nodes, setNodes] = useState([]);
   const [edges, setEdges] = useState([]);
@@ -130,13 +141,18 @@ export default function Home() {
       });
 
       const mapped = [];
-      let row = 0;
+      let currentY = 40;
       Object.values(groups).forEach((containers) => {
+        let maxHeight = BASE_NODE_HEIGHT;
         containers.forEach((c, i) => {
+          const estimatedHeight = estimateNodeHeight(c);
+          if (estimatedHeight > maxHeight) {
+            maxHeight = estimatedHeight;
+          }
           mapped.push({
             id: c.id,
             type: 'container',
-            position: { x: 40 + i * 220, y: 40 + row * 220 },
+            position: { x: 40 + i * 220, y: currentY },
             data: {
               ...c,
               onRestart: () => handleAction(c.id, 'restart'),
@@ -147,7 +163,7 @@ export default function Home() {
             },
           });
         });
-        row++;
+        currentY += maxHeight + ROW_VERTICAL_GAP;
       });
 
       const generatedEdges = [];

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -51,15 +51,17 @@ function ContainerNode({ data }) {
         {data.ports?.length > 0 && (
           <div className="text-xs text-gray-600 mb-2 space-y-0.5">
             {data.ports.map((port) => {
-              const key = `${port.host_port || ''}-${port.container_port || ''}`;
-              const mapping = port.container_port ? ` → ${port.container_port}` : '';
-              const description = port.host_ip
-                ? `${port.host_ip}:${port.host_port}${mapping}`
-                : `${port.host_port}${mapping}`;
+              const key = `${port.host_ip || 'all'}-${port.host_port || 'unknown'}-${port.container_port || 'none'}`;
+              const hostLabel = port.host_ip ? `${port.host_ip}:${port.host_port}` : port.host_port;
+              const containerLabel = port.container_port ? `Container: ${port.container_port}` : null;
+              const descriptionParts = [];
+              if (hostLabel) descriptionParts.push(`Host: ${hostLabel}`);
+              if (containerLabel) descriptionParts.push(containerLabel);
+              const description = descriptionParts.join(' → ');
               return (
                 <div key={key} className="truncate" title={description}>
-                  Externo: {port.host_port}
-                  {port.container_port ? ` → ${port.container_port}` : ''}
+                  Host: {hostLabel || '—'}
+                  {port.container_port ? ` → Container: ${port.container_port}` : ''}
                 </div>
               );
             })}
@@ -134,7 +136,7 @@ export default function Home() {
           mapped.push({
             id: c.id,
             type: 'container',
-            position: { x: 40 + i * 220, y: 40 + row * 180 },
+            position: { x: 40 + i * 220, y: 40 + row * 220 },
             data: {
               ...c,
               onRestart: () => handleAction(c.id, 'restart'),

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -48,6 +48,23 @@ function ContainerNode({ data }) {
           <span className="font-semibold truncate text-black" title={data.name}>{data.name}</span>
         </div>
         <div className="text-xs text-gray-600 mb-2 truncate" title={data.image}>{data.image}</div>
+        {data.ports?.length > 0 && (
+          <div className="text-xs text-gray-600 mb-2 space-y-0.5">
+            {data.ports.map((port) => {
+              const key = `${port.host_port || ''}-${port.container_port || ''}`;
+              const mapping = port.container_port ? ` → ${port.container_port}` : '';
+              const description = port.host_ip
+                ? `${port.host_ip}:${port.host_port}${mapping}`
+                : `${port.host_port}${mapping}`;
+              return (
+                <div key={key} className="truncate" title={description}>
+                  Externo: {port.host_port}
+                  {port.container_port ? ` → ${port.container_port}` : ''}
+                </div>
+              );
+            })}
+          </div>
+        )}
         <div className="flex gap-1 justify-end">
           <button
             onClick={data.onRestart}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -113,7 +113,7 @@ function ContainerNode({ data }) {
 const BASE_NODE_HEIGHT = 240;
 const PORT_LINE_HEIGHT = 18;
 const PORT_SECTION_PADDING = 12;
-const ROW_VERTICAL_GAP = 20;
+const ROW_VERTICAL_GAP = 8;
 
 function estimateNodeHeight(container) {
   const portCount = container?.ports?.length || 0;

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -49,22 +49,28 @@ function ContainerNode({ data }) {
         </div>
         <div className="text-xs text-gray-600 mb-2 truncate" title={data.image}>{data.image}</div>
         {data.ports?.length > 0 && (
-          <div className="text-xs text-gray-600 mb-2 space-y-0.5">
-            {data.ports.map((port) => {
-              const key = `${port.host_ip || 'all'}-${port.host_port || 'unknown'}-${port.container_port || 'none'}`;
-              const hostLabel = port.host_ip ? `${port.host_ip}:${port.host_port}` : port.host_port;
-              const containerLabel = port.container_port ? `Container: ${port.container_port}` : null;
-              const descriptionParts = [];
-              if (hostLabel) descriptionParts.push(`Host: ${hostLabel}`);
-              if (containerLabel) descriptionParts.push(containerLabel);
-              const description = descriptionParts.join(' → ');
-              return (
-                <div key={key} className="truncate" title={description}>
-                  Host: {hostLabel || '—'}
-                  {port.container_port ? ` → Container: ${port.container_port}` : ''}
-                </div>
-              );
-            })}
+          <div className="text-xs text-gray-600 mb-2">
+            <div className="font-semibold text-gray-700 uppercase tracking-wide text-[10px] mb-1">Ports</div>
+            <div className="space-y-1">
+              {data.ports.map((port) => {
+                const key = `${port.host_ip || 'all'}-${port.host_port || 'unknown'}-${port.container_port || 'none'}`;
+                const hostLabel = port.host_ip ? `${port.host_ip}:${port.host_port}` : port.host_port;
+                const [containerBase, protocol] = (port.container_port || '').split('/');
+                const containerLabel = containerBase ? `${containerBase}${protocol ? `/${protocol.toUpperCase()}` : ''}` : null;
+                const tooltipDetails = [
+                  hostLabel ? `External: ${hostLabel}` : null,
+                  containerLabel ? `Internal: ${containerLabel}` : null,
+                ]
+                  .filter(Boolean)
+                  .join(' → ');
+                return (
+                  <div key={key} className="space-y-0.5" title={tooltipDetails}>
+                    <div className="truncate">External: {hostLabel || '—'}</div>
+                    {containerLabel && <div className="truncate text-gray-500">Internal: {containerLabel}</div>}
+                  </div>
+                );
+              })}
+            </div>
           </div>
         )}
         <div className="flex gap-1 justify-end">

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -107,7 +107,7 @@ function ContainerNode({ data }) {
 const BASE_NODE_HEIGHT = 240;
 const PORT_LINE_HEIGHT = 18;
 const PORT_SECTION_PADDING = 12;
-const ROW_VERTICAL_GAP = 40;
+const ROW_VERTICAL_GAP = 20;
 
 function estimateNodeHeight(container) {
   const portCount = container?.ports?.length || 0;


### PR DESCRIPTION
## Summary
- include published port bindings in the container API response
- render each container card with its available external to internal port mappings

## Testing
- not run (per instructions)


------
https://chatgpt.com/codex/tasks/task_e_68cf09a5987c832c93503e628242dad7