### PR TITLE
Add application-aware grouping with background scanner and metadata services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Dumb Docker
 
+<p align="center">
+  <img src="frontend/public/favicon.svg" alt="Dumb Docker logo" width="120" />
+</p>
+
 **Dumb Docker** is a lightweight dashboard for self-hosters.
 It helps you see, organize, and control Docker containers running on your VPS.
 
@@ -13,6 +17,14 @@ It helps you see, organize, and control Docker containers running on your VPS.
 - 📊 See per-application resource share
 
 Great for personal servers, homelabs, and small production VPS deployments.
+
+## Visual preview
+
+<p align="center">
+  <img src="frontend/public/favicon.svg" alt="Dumb Docker icon" width="96" />
+</p>
+
+Dumb Docker was designed to be friendly and practical: open the panel, see your apps, click to manage containers, done.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ BACKEND_URL=http://localhost:8000 npm run dev
 
 Dumb Docker now scans application roots and groups container cards by project.
 
+### Backend filesystem access
+
+When running with Docker Compose, the backend service must be able to read host project folders. The provided `docker-compose.yml` mounts `/opt`, `/srv`, and `/var/www` into the backend container as read-only so application discovery can find `.git` and compose files.
+
 ### Backend scan configuration
 
 You can configure application discovery in `backend/config.yml`:

--- a/README.md
+++ b/README.md
@@ -73,3 +73,31 @@ routes know where to proxy requests, for example:
 ```bash
 BACKEND_URL=http://localhost:8000 npm run dev
 ```
+
+## Application-aware dashboard
+
+Dumb Docker now scans application roots and groups container cards by project.
+
+### Backend scan configuration
+
+You can configure application discovery in `backend/config.yml`:
+
+```yaml
+applications:
+  scanPaths:
+    - /opt
+    - /srv
+    - /var/www
+  scanIntervalSeconds: 60
+```
+
+Environment overrides are also supported:
+
+- `APPLICATION_SCAN_PATHS` (comma-separated list)
+- `APPLICATION_SCAN_INTERVAL_SECONDS`
+
+### New API endpoints
+
+- `GET /api/applications`
+- `GET /api/applications/:id`
+- `GET /api/applications/:id/git-status`

--- a/README.md
+++ b/README.md
@@ -1,90 +1,107 @@
 # Dumb Docker
 
-This repository contains a small Docker Compose setup that runs a Next.js
-dashboard and a FastAPI API. The frontend visualises the Docker containers on
-your machine using [React Flow](https://reactflow.dev) and lets you start, stop
-or restart them and view their logs. API calls are proxied through Next.js to
-the backend so both services can talk to the local Docker daemon.
+**Dumb Docker** is a lightweight dashboard for self-hosters.
+It helps you see, organize, and control Docker containers running on your VPS.
 
-## Features
+## Why use it?
 
-- Next.js frontend secured with [NextAuth](https://next-auth.js.org) Credentials provider
-- Graph view of your containers powered by React Flow
-- Start, stop and restart containers from the UI
-- View container logs directly in the browser
-- FastAPI backend that communicates with the Docker socket
+- 🐳 View all containers in one place
+- 📦 Group containers by application/repository
+- 🔗 Show GitHub repo link, branch, and commit for each app
+- 🔄 Restart/stop containers quickly
+- 📜 Read logs in the browser
+- 📊 See per-application resource share
 
-## Environment Variables
+Great for personal servers, homelabs, and small production VPS deployments.
 
-The following variables can be defined in a `.env` file at the repository root:
+---
 
-- `FRONTEND_PORT` – host port used for the Next.js app (default `3000`).
-- `BACKEND_PORT` – host port used for the FastAPI backend (default `8000`).
-- `BACKEND_URL` – address of the backend when the frontend runs outside
-  Docker Compose.
+## Quick Start (Docker Compose)
 
-The frontend also requires a separate `.env` file under `frontend/` for the
-authentication settings. See `frontend/.env.example` for the full list, but the
-important ones are:
-
-- `NEXTAUTH_SECRET` – random string used to sign NextAuth sessions.
-- `ADMIN_USERNAME` and either `ADMIN_PASSWORD_SHA256` or `ADMIN_PASSWORD` –
-  credentials for the admin login.
-
-Example root `.env` file:
+### 1) Clone
 
 ```bash
+git clone https://github.com/Bobagi/dumb-docker.git
+cd dumb-docker
+```
+
+### 2) Create root `.env`
+
+```bash
+cat > .env <<EOF
 FRONTEND_PORT=3000
 BACKEND_PORT=8000
+EOF
 ```
-The Compose CLI automatically loads variables from this file.
 
-If you are running in GitHub Codespaces, make sure these ports are forwarded in your devcontainer or compose configuration so the API proxy works correctly.
+### 3) Configure login for dashboard
 
-## Setup
-
-Before starting the containers, install the frontend dependencies. The compose file mounts the source and runs `npm run dev`, so the packages must be installed. Docker Compose will install them automatically, but doing it manually first speeds up the initial boot.
+Create `frontend/.env` (or copy from `frontend/.env.example`):
 
 ```bash
-cd frontend && npm install
+cp frontend/.env.example frontend/.env
 ```
 
-This is required because `docker-compose.yml` mounts the frontend source and
-executes `npm run dev`. The dev server fails to start if `node_modules` is
-missing.
+Set at least:
 
-## Development
+- `NEXTAUTH_SECRET`
+- `ADMIN_USERNAME`
+- `ADMIN_PASSWORD` **or** `ADMIN_PASSWORD_SHA256`
 
-Run the application with Docker Compose. The first time you run it, include the
-`--build` flag so the backend dependencies are installed:
+### 4) Start
 
 ```bash
-docker-compose up --build
+docker compose up --build
 ```
 
-This starts the frontend on the port defined in `FRONTEND_PORT` (default `3000`)
-and the FastAPI backend on the port defined in `BACKEND_PORT` (default `8000`).
-The backend source is mounted with `uvicorn --reload`, so code changes take
-effect immediately once the containers are up.
+Open: `http://YOUR_SERVER_IP:3000`
 
-If you run the Next.js app without Docker Compose, set `BACKEND_URL` so the API
-routes know where to proxy requests, for example:
+---
+
+## Daily commands
+
+### Restart stack
 
 ```bash
-BACKEND_URL=http://localhost:8000 npm run dev
+docker compose down
+docker compose up --build -d
 ```
 
-## Application-aware dashboard
+### See logs
 
-Dumb Docker now scans application roots and groups container cards by project.
+```bash
+docker compose logs -f
+```
 
-### Backend filesystem access
+### Update after pulling new code
 
-When running with Docker Compose, the backend service must be able to read host project folders. The provided `docker-compose.yml` mounts `/opt`, `/srv`, and `/var/www` into the backend container as read-only so application discovery can find `.git` and compose files.
+```bash
+git pull
+docker compose down
+docker compose up --build -d
+```
 
-### Backend scan configuration
+---
 
-You can configure application discovery in `backend/config.yml`:
+## Application-aware scan
+
+The backend scans these paths by default:
+
+- `/opt`
+- `/srv`
+- `/var/www`
+
+An app is detected when a folder has at least one of:
+
+- `.git`
+- `docker-compose.yml` / `docker-compose.yaml` / `compose.yml` / `compose.yaml`
+- `Dockerfile`
+
+`docker-compose.yml` already mounts these host paths read-only into the backend container so discovery works on VPS.
+
+### Scanner config
+
+`backend/config.yml`:
 
 ```yaml
 applications:
@@ -95,13 +112,26 @@ applications:
   scanIntervalSeconds: 60
 ```
 
-Environment overrides are also supported:
+You can override with env vars:
 
-- `APPLICATION_SCAN_PATHS` (comma-separated list)
+- `APPLICATION_SCAN_PATHS` (comma-separated)
 - `APPLICATION_SCAN_INTERVAL_SECONDS`
 
-### New API endpoints
+---
+
+## API endpoints
+
+Existing container endpoints remain available.
+
+New endpoints:
 
 - `GET /api/applications`
 - `GET /api/applications/:id`
 - `GET /api/applications/:id/git-status`
+
+---
+
+## Notes
+
+- This project is optimized for practical VPS usage.
+- If you run from Docker Compose, rebuild on backend changes to ensure dependencies/tools (like `git`) are present inside the backend container.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends git && rm -rf /var/lib/apt/lists/*
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 COPY . .

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,39 @@
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+import yaml
+
+
+@dataclass
+class ApplicationConfig:
+    scan_paths: List[str]
+    scan_interval_seconds: int
+
+
+def load_application_config() -> ApplicationConfig:
+    default_paths = ["/opt", "/srv", "/var/www"]
+    default_interval = 60
+
+    config_path = Path(os.getenv("DUMBDOCKER_CONFIG_PATH", "/app/config.yml"))
+    paths = default_paths
+    interval = default_interval
+
+    if config_path.exists():
+        try:
+            config_data = yaml.safe_load(config_path.read_text()) or {}
+            app_config = config_data.get("applications", {})
+            paths = app_config.get("scanPaths") or paths
+            interval = int(app_config.get("scanIntervalSeconds") or interval)
+        except Exception:
+            pass
+
+    env_paths = os.getenv("APPLICATION_SCAN_PATHS")
+    env_interval = os.getenv("APPLICATION_SCAN_INTERVAL_SECONDS")
+    if env_paths:
+        paths = [p.strip() for p in env_paths.split(",") if p.strip()]
+    if env_interval:
+        interval = int(env_interval)
+
+    return ApplicationConfig(scan_paths=paths, scan_interval_seconds=max(5, interval))

--- a/backend/config.yml
+++ b/backend/config.yml
@@ -1,0 +1,6 @@
+applications:
+  scanPaths:
+    - /opt
+    - /srv
+    - /var/www
+  scanIntervalSeconds: 60

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,10 +1,32 @@
-from fastapi import FastAPI, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
+import asyncio
+
 import docker
 from docker.errors import APIError, ImageNotFound, NotFound
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+
+from config import load_application_config
+from services import (
+    ApplicationAggregationService,
+    ApplicationDiscoveryService,
+    ApplicationRegistry,
+    ContainerAssociationService,
+    DockerService,
+    GitMetadataService,
+)
 
 app = FastAPI()
-client = docker.DockerClient(base_url='unix://var/run/docker.sock')
+client = docker.DockerClient(base_url="unix://var/run/docker.sock")
+
+docker_service = DockerService(client)
+git_metadata_service = GitMetadataService()
+app_discovery_service = ApplicationDiscoveryService(git_metadata_service)
+association_service = ContainerAssociationService()
+aggregation_service = ApplicationAggregationService()
+application_registry = ApplicationRegistry()
+app_config = load_application_config()
+
+scan_task = None
 
 app.add_middleware(
     CORSMiddleware,
@@ -13,44 +35,41 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+async def run_application_scan():
+    applications = await asyncio.to_thread(app_discovery_service.discover, app_config.scan_paths)
+    containers = await asyncio.to_thread(docker_service.list_containers_for_association)
+    associations = association_service.associate(applications, containers)
+    aggregated = aggregation_service.aggregate(applications, associations)
+    await application_registry.set_applications(aggregated)
+
+
+async def scan_loop():
+    while True:
+        try:
+            await run_application_scan()
+        except Exception:
+            # scanner must remain non-blocking and resilient
+            pass
+        await asyncio.sleep(app_config.scan_interval_seconds)
+
+
+@app.on_event("startup")
+async def on_startup():
+    global scan_task
+    await run_application_scan()
+    scan_task = asyncio.create_task(scan_loop())
+
+
+@app.on_event("shutdown")
+async def on_shutdown():
+    if scan_task:
+        scan_task.cancel()
+
+
 @app.get("/api/containers")
 def get_containers():
-    containers = client.containers.list(all=True)
-    result = []
-    for c in containers:
-        ports = []
-        port_map = {}
-        network_ports = c.attrs.get("NetworkSettings", {}).get("Ports") or {}
-        for container_port, bindings in network_ports.items():
-            if not bindings:
-                continue
-            for binding in bindings:
-                host_port = binding.get("HostPort")
-                if not host_port:
-                    continue
-                host_ip = binding.get("HostIp")
-                key = (container_port, host_port)
-                existing = port_map.get(key)
-                prefers_current = existing and existing.get("host_ip") not in (None, "", "::")
-                prefers_new = host_ip not in (None, "", "::")
-                if existing and (prefers_current or not prefers_new):
-                    continue
-                port_map[key] = {
-                    "host_port": host_port,
-                    "container_port": container_port,
-                    "host_ip": host_ip,
-                }
-        if port_map:
-            ports = list(port_map.values())
-        result.append({
-            "id": c.id,
-            "name": c.name,
-            "status": c.status,
-            "image": c.image.tags[0] if c.image.tags else "",
-            "project": c.labels.get("com.docker.compose.project"),
-            "ports": ports,
-        })
-    return result
+    return docker_service.list_containers()
 
 
 @app.post("/api/containers/{container_id}/restart")
@@ -87,7 +106,6 @@ def delete_container_image(container_id: str):
         if container.status == "running":
             container.stop()
     except APIError:
-        # Ignore failures when stopping; force removal below covers it
         pass
 
     try:
@@ -103,3 +121,29 @@ def delete_container_image(container_id: str):
         raise HTTPException(status_code=400, detail=str(getattr(exc, "explanation", exc))) from exc
 
     return {"result": "image_deleted"}
+
+
+@app.get("/api/applications")
+async def get_applications():
+    return await application_registry.get_applications()
+
+
+@app.get("/api/applications/{application_id}")
+async def get_application(application_id: str):
+    app_data = await application_registry.get_application(application_id)
+    if not app_data:
+        raise HTTPException(status_code=404, detail="Application not found")
+    return app_data
+
+
+@app.get("/api/applications/{application_id}/git-status")
+async def get_application_git_status(application_id: str):
+    app_data = await application_registry.get_application(application_id)
+    if not app_data:
+        raise HTTPException(status_code=404, detail="Application not found")
+    path = app_data.get("path")
+    if not path:
+        raise HTTPException(status_code=400, detail="Application has no filesystem path")
+    from pathlib import Path
+
+    return await asyncio.to_thread(git_metadata_service.get_git_status, Path(path))

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,6 @@
 import asyncio
+import logging
+from pathlib import Path
 
 import docker
 from docker.errors import APIError, ImageNotFound, NotFound
@@ -18,6 +20,9 @@ from services import (
 app = FastAPI()
 client = docker.DockerClient(base_url="unix://var/run/docker.sock")
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("dumbdocker.app-scanner")
+
 docker_service = DockerService(client)
 git_metadata_service = GitMetadataService()
 app_discovery_service = ApplicationDiscoveryService(git_metadata_service)
@@ -36,6 +41,12 @@ app.add_middleware(
 )
 
 
+def _log_scan_paths():
+    for scan_path in app_config.scan_paths:
+        exists = Path(scan_path).exists()
+        logger.info("scan_path=%s exists=%s", scan_path, exists)
+
+
 async def run_application_scan():
     applications = await asyncio.to_thread(app_discovery_service.discover, app_config.scan_paths)
     containers = await asyncio.to_thread(docker_service.list_containers_for_association)
@@ -43,20 +54,29 @@ async def run_application_scan():
     aggregated = aggregation_service.aggregate(applications, associations)
     await application_registry.set_applications(aggregated)
 
+    assigned_count = sum(len(associations.get(app.id, [])) for app in applications)
+    unassigned_count = len(associations.get("unassigned", []))
+    logger.info(
+        "scan_complete applications=%s assigned_containers=%s unassigned_containers=%s",
+        len(applications),
+        assigned_count,
+        unassigned_count,
+    )
+
 
 async def scan_loop():
     while True:
         try:
             await run_application_scan()
         except Exception:
-            # scanner must remain non-blocking and resilient
-            pass
+            logger.exception("scan_failed")
         await asyncio.sleep(app_config.scan_interval_seconds)
 
 
 @app.on_event("startup")
 async def on_startup():
     global scan_task
+    _log_scan_paths()
     await run_application_scan()
     scan_task = asyncio.create_task(scan_loop())
 
@@ -144,6 +164,5 @@ async def get_application_git_status(application_id: str):
     path = app_data.get("path")
     if not path:
         raise HTTPException(status_code=400, detail="Application has no filesystem path")
-    from pathlib import Path
 
     return await asyncio.to_thread(git_metadata_service.get_git_status, Path(path))

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 docker
+pyyaml

--- a/backend/services.py
+++ b/backend/services.py
@@ -2,11 +2,11 @@ import asyncio
 import hashlib
 import json
 import os
-from dataclasses import dataclass, asdict
+import subprocess
+from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
-import subprocess
 
 import docker
 
@@ -66,6 +66,11 @@ class DockerService:
         if include_internal:
             payload["labels"] = container.labels or {}
             payload["working_dir"] = container.attrs.get("Config", {}).get("WorkingDir")
+            payload["mount_sources"] = [
+                mount.get("Source")
+                for mount in (container.attrs.get("Mounts") or [])
+                if mount.get("Type") == "bind" and mount.get("Source")
+            ]
         return payload
 
     def list_containers(self) -> List[dict]:
@@ -137,7 +142,14 @@ class GitMetadataService:
 
 
 class ApplicationDiscoveryService:
-    DISCOVERY_MARKERS = (".git", "docker-compose.yml", "Dockerfile")
+    DISCOVERY_MARKERS = (
+        ".git",
+        "docker-compose.yml",
+        "docker-compose.yaml",
+        "compose.yml",
+        "compose.yaml",
+        "Dockerfile",
+    )
 
     def __init__(self, git_service: GitMetadataService):
         self.git_service = git_service
@@ -208,10 +220,18 @@ class ApplicationDiscoveryService:
 
 
 class ContainerAssociationService:
+    def _find_app_by_prefix_path(self, candidate_path: str, apps_by_path: List[Tuple[str, str]]) -> Optional[str]:
+        normalized = str(Path(candidate_path).resolve())
+        for app_path, app_id in apps_by_path:
+            if normalized == app_path or normalized.startswith(f"{app_path}/"):
+                return app_id
+        return None
+
     def associate(self, applications: List[Application], containers: List[dict]) -> Dict[str, List[dict]]:
         app_by_id = {app.id: app for app in applications}
         app_by_name = {app.name.lower(): app.id for app in applications}
         app_by_folder = {Path(app.path).name.lower(): app.id for app in applications}
+        apps_by_path = sorted(((app.path, app.id) for app in applications), key=lambda item: len(item[0]), reverse=True)
 
         associations: Dict[str, List[dict]] = {app.id: [] for app in applications}
         associations["unassigned"] = []
@@ -221,22 +241,29 @@ class ContainerAssociationService:
             labels = container.get("labels") or {}
             explicit_app = labels.get("com.dumbdocker.app")
             if explicit_app:
-                app_id = app_by_name.get(explicit_app.lower()) or explicit_app
-                if app_id not in app_by_id:
-                    app_id = None
+                normalized = explicit_app.lower()
+                app_id = (
+                    app_by_id.get(explicit_app)
+                    or app_by_name.get(normalized)
+                    or app_by_folder.get(normalized)
+                )
 
             if not app_id:
                 compose_project = labels.get("com.docker.compose.project") or container.get("project")
                 if compose_project:
-                    app_id = app_by_name.get(compose_project.lower()) or app_by_folder.get(compose_project.lower())
+                    normalized = compose_project.lower()
+                    app_id = app_by_name.get(normalized) or app_by_folder.get(normalized)
+
+            if not app_id:
+                for mount_source in container.get("mount_sources") or []:
+                    app_id = self._find_app_by_prefix_path(mount_source, apps_by_path)
+                    if app_id:
+                        break
 
             if not app_id:
                 working_dir = (container.get("working_dir") or "").rstrip("/")
                 if working_dir:
-                    for app in applications:
-                        if working_dir.startswith(app.path):
-                            app_id = app.id
-                            break
+                    app_id = self._find_app_by_prefix_path(working_dir, apps_by_path)
 
             if not app_id:
                 cname = (container.get("name") or "").lower()
@@ -246,7 +273,7 @@ class ContainerAssociationService:
                         break
 
             target = app_id if app_id in associations else "unassigned"
-            clean_container = {k: v for k, v in container.items() if k not in {"labels", "working_dir"}}
+            clean_container = {k: v for k, v in container.items() if k not in {"labels", "working_dir", "mount_sources"}}
             associations[target].append(clean_container)
         return associations
 

--- a/backend/services.py
+++ b/backend/services.py
@@ -113,7 +113,7 @@ class GitMetadataService:
     def _run_git(self, args: List[str], cwd: Path) -> Optional[str]:
         try:
             result = subprocess.run(
-                ["git", *args],
+                ["git", "-c", f"safe.directory={cwd}", *args],
                 cwd=str(cwd),
                 capture_output=True,
                 text=True,

--- a/backend/services.py
+++ b/backend/services.py
@@ -1,0 +1,293 @@
+import asyncio
+import hashlib
+import json
+import os
+from dataclasses import dataclass, asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+import subprocess
+
+import docker
+
+
+@dataclass
+class Application:
+    id: str
+    name: str
+    path: str
+    gitRemoteUrl: Optional[str]
+    gitBranch: Optional[str]
+    gitCommit: Optional[str]
+    description: Optional[str]
+    summary: Optional[str]
+    containers: List[dict]
+    lastScanTimestamp: str
+
+
+class DockerService:
+    def __init__(self, client: docker.DockerClient):
+        self.client = client
+
+    def _serialize_container(self, container, include_internal: bool = False):
+        ports = []
+        port_map = {}
+        network_ports = container.attrs.get("NetworkSettings", {}).get("Ports") or {}
+        for container_port, bindings in network_ports.items():
+            if not bindings:
+                continue
+            for binding in bindings:
+                host_port = binding.get("HostPort")
+                if not host_port:
+                    continue
+                host_ip = binding.get("HostIp")
+                key = (container_port, host_port)
+                existing = port_map.get(key)
+                prefers_current = existing and existing.get("host_ip") not in (None, "", "::")
+                prefers_new = host_ip not in (None, "", "::")
+                if existing and (prefers_current or not prefers_new):
+                    continue
+                port_map[key] = {
+                    "host_port": host_port,
+                    "container_port": container_port,
+                    "host_ip": host_ip,
+                }
+        if port_map:
+            ports = list(port_map.values())
+
+        payload = {
+            "id": container.id,
+            "name": container.name,
+            "status": container.status,
+            "image": container.image.tags[0] if container.image.tags else "",
+            "project": container.labels.get("com.docker.compose.project"),
+            "ports": ports,
+        }
+        if include_internal:
+            payload["labels"] = container.labels or {}
+            payload["working_dir"] = container.attrs.get("Config", {}).get("WorkingDir")
+        return payload
+
+    def list_containers(self) -> List[dict]:
+        containers = self.client.containers.list(all=True)
+        return [self._serialize_container(c) for c in containers]
+
+    def list_containers_for_association(self) -> List[dict]:
+        containers = self.client.containers.list(all=True)
+        return [self._serialize_container(c, include_internal=True) for c in containers]
+
+
+class GitMetadataService:
+    def _run_git(self, args: List[str], cwd: Path) -> Optional[str]:
+        try:
+            result = subprocess.run(
+                ["git", *args],
+                cwd=str(cwd),
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            if result.returncode != 0:
+                return None
+            return result.stdout.strip() or None
+        except (subprocess.SubprocessError, FileNotFoundError):
+            return None
+
+    def read_repo_metadata(self, path: Path) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+        remote = self._run_git(["remote", "get-url", "origin"], path)
+        branch = self._run_git(["rev-parse", "--abbrev-ref", "HEAD"], path)
+        commit = self._run_git(["rev-parse", "HEAD"], path)
+        return remote, branch, commit
+
+    def get_git_status(self, path: Path) -> dict:
+        local_commit = self._run_git(["rev-parse", "HEAD"], path)
+        branch = self._run_git(["rev-parse", "--abbrev-ref", "HEAD"], path)
+        if not branch:
+            return {
+                "localCommit": local_commit,
+                "remoteCommit": None,
+                "ahead": 0,
+                "behind": 0,
+                "status": "unknown",
+            }
+        self._run_git(["fetch", "origin", branch], path)
+        remote_commit = self._run_git(["rev-parse", f"origin/{branch}"], path)
+        ahead_behind = self._run_git(["rev-list", "--left-right", "--count", f"origin/{branch}...HEAD"], path)
+        ahead, behind = 0, 0
+        if ahead_behind:
+            parts = ahead_behind.split()
+            if len(parts) == 2:
+                behind = int(parts[0])
+                ahead = int(parts[1])
+        status = "up-to-date"
+        if ahead and behind:
+            status = "diverged"
+        elif ahead:
+            status = "ahead"
+        elif behind:
+            status = "behind"
+        return {
+            "localCommit": local_commit,
+            "remoteCommit": remote_commit,
+            "ahead": ahead,
+            "behind": behind,
+            "status": status,
+        }
+
+
+class ApplicationDiscoveryService:
+    DISCOVERY_MARKERS = (".git", "docker-compose.yml", "Dockerfile")
+
+    def __init__(self, git_service: GitMetadataService):
+        self.git_service = git_service
+
+    def _is_application_dir(self, path: Path) -> bool:
+        return any((path / marker).exists() for marker in self.DISCOVERY_MARKERS)
+
+    def _extract_readme_summary(self, path: Path) -> Optional[str]:
+        readme_path = path / "README.md"
+        if not readme_path.exists():
+            return None
+        try:
+            content = readme_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            return None
+        paragraphs = [p.strip() for p in content.split("\n\n") if p.strip()]
+        if not paragraphs:
+            return None
+        first = paragraphs[0]
+        lines = [line.strip("# ") for line in first.splitlines() if line.strip()]
+        return " ".join(lines) if lines else None
+
+    def _extract_package_metadata(self, path: Path) -> Tuple[Optional[str], Optional[str]]:
+        package_json = path / "package.json"
+        if not package_json.exists():
+            return None, None
+        try:
+            data = json.loads(package_json.read_text(encoding="utf-8", errors="ignore"))
+        except (OSError, json.JSONDecodeError):
+            return None, None
+        return data.get("name"), data.get("description")
+
+    def discover(self, scan_paths: List[str]) -> List[Application]:
+        discovered: List[Application] = []
+        now = datetime.now(timezone.utc).isoformat()
+        for root in scan_paths:
+            root_path = Path(root)
+            if not root_path.exists() or not root_path.is_dir():
+                continue
+            for current, dirs, _ in os.walk(root):
+                current_path = Path(current)
+                if not self._is_application_dir(current_path):
+                    continue
+                app_path = str(current_path.resolve())
+                app_name = current_path.name
+                package_name, description = self._extract_package_metadata(current_path)
+                summary = self._extract_readme_summary(current_path)
+                git_remote = git_branch = git_commit = None
+                if (current_path / ".git").exists():
+                    git_remote, git_branch, git_commit = self.git_service.read_repo_metadata(current_path)
+                app_id = hashlib.sha1(app_path.encode("utf-8")).hexdigest()[:16]
+                discovered.append(
+                    Application(
+                        id=app_id,
+                        name=package_name or app_name,
+                        path=app_path,
+                        gitRemoteUrl=git_remote,
+                        gitBranch=git_branch,
+                        gitCommit=git_commit,
+                        description=description,
+                        summary=summary,
+                        containers=[],
+                        lastScanTimestamp=now,
+                    )
+                )
+                dirs[:] = []
+        return discovered
+
+
+class ContainerAssociationService:
+    def associate(self, applications: List[Application], containers: List[dict]) -> Dict[str, List[dict]]:
+        app_by_id = {app.id: app for app in applications}
+        app_by_name = {app.name.lower(): app.id for app in applications}
+        app_by_folder = {Path(app.path).name.lower(): app.id for app in applications}
+
+        associations: Dict[str, List[dict]] = {app.id: [] for app in applications}
+        associations["unassigned"] = []
+
+        for container in containers:
+            app_id = None
+            labels = container.get("labels") or {}
+            explicit_app = labels.get("com.dumbdocker.app")
+            if explicit_app:
+                app_id = app_by_name.get(explicit_app.lower()) or explicit_app
+                if app_id not in app_by_id:
+                    app_id = None
+
+            if not app_id:
+                compose_project = labels.get("com.docker.compose.project") or container.get("project")
+                if compose_project:
+                    app_id = app_by_name.get(compose_project.lower()) or app_by_folder.get(compose_project.lower())
+
+            if not app_id:
+                working_dir = (container.get("working_dir") or "").rstrip("/")
+                if working_dir:
+                    for app in applications:
+                        if working_dir.startswith(app.path):
+                            app_id = app.id
+                            break
+
+            if not app_id:
+                cname = (container.get("name") or "").lower()
+                for folder_name, candidate_id in app_by_folder.items():
+                    if folder_name and folder_name in cname:
+                        app_id = candidate_id
+                        break
+
+            target = app_id if app_id in associations else "unassigned"
+            clean_container = {k: v for k, v in container.items() if k not in {"labels", "working_dir"}}
+            associations[target].append(clean_container)
+        return associations
+
+
+class ApplicationAggregationService:
+    def aggregate(self, applications: List[Application], associations: Dict[str, List[dict]]) -> List[dict]:
+        payload = []
+        for app in applications:
+            app.containers = associations.get(app.id, [])
+            payload.append(asdict(app))
+        payload.sort(key=lambda item: item["name"].lower())
+        payload.append(
+            {
+                "id": "unassigned",
+                "name": "Unassigned Containers",
+                "path": None,
+                "gitRemoteUrl": None,
+                "gitBranch": None,
+                "gitCommit": None,
+                "description": None,
+                "summary": None,
+                "containers": associations.get("unassigned", []),
+                "lastScanTimestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        return payload
+
+
+class ApplicationRegistry:
+    def __init__(self):
+        self._applications: List[dict] = []
+        self._lock = asyncio.Lock()
+
+    async def set_applications(self, applications: List[dict]):
+        async with self._lock:
+            self._applications = applications
+
+    async def get_applications(self) -> List[dict]:
+        async with self._lock:
+            return list(self._applications)
+
+    async def get_application(self, app_id: str) -> Optional[dict]:
+        async with self._lock:
+            return next((app for app in self._applications if app["id"] == app_id), None)

--- a/backend/services.py
+++ b/backend/services.py
@@ -64,6 +64,8 @@ class DockerService:
             "ports": ports,
         }
         if include_internal:
+            usage = self._read_container_usage(container)
+            payload.update(usage)
             payload["labels"] = container.labels or {}
             payload["working_dir"] = container.attrs.get("Config", {}).get("WorkingDir")
             payload["mount_sources"] = [
@@ -72,6 +74,31 @@ class DockerService:
                 if mount.get("Type") == "bind" and mount.get("Source")
             ]
         return payload
+
+    def _read_container_usage(self, container) -> dict:
+        try:
+            stats = container.stats(stream=False)
+        except Exception:
+            return {"cpu_percent": 0.0, "memory_usage": 0, "memory_limit": 0}
+
+        cpu_percent = 0.0
+        try:
+            cpu_total = (stats.get("cpu_stats", {}).get("cpu_usage", {}) or {}).get("total_usage", 0)
+            prev_cpu_total = (stats.get("precpu_stats", {}).get("cpu_usage", {}) or {}).get("total_usage", 0)
+            system_total = (stats.get("cpu_stats", {}) or {}).get("system_cpu_usage", 0)
+            prev_system_total = (stats.get("precpu_stats", {}) or {}).get("system_cpu_usage", 0)
+            cpu_delta = cpu_total - prev_cpu_total
+            system_delta = system_total - prev_system_total
+            online_cpus = (stats.get("cpu_stats", {}) or {}).get("online_cpus") or 1
+            if cpu_delta > 0 and system_delta > 0:
+                cpu_percent = (cpu_delta / system_delta) * online_cpus * 100.0
+        except Exception:
+            cpu_percent = 0.0
+
+        memory = stats.get("memory_stats", {}) or {}
+        memory_usage = int(memory.get("usage") or 0)
+        memory_limit = int(memory.get("limit") or 0)
+        return {"cpu_percent": round(cpu_percent, 3), "memory_usage": memory_usage, "memory_limit": memory_limit}
 
     def list_containers(self) -> List[dict]:
         containers = self.client.containers.list(all=True)
@@ -279,13 +306,23 @@ class ContainerAssociationService:
 
 
 class ApplicationAggregationService:
+    def _with_usage(self, app_data: dict) -> dict:
+        containers = app_data.get("containers") or []
+        app_cpu_percent = sum(float(c.get("cpu_percent") or 0.0) for c in containers)
+        app_memory_usage = sum(int(c.get("memory_usage") or 0) for c in containers)
+        app_data["resourceUsage"] = {
+            "cpuPercent": round(app_cpu_percent, 3),
+            "memoryBytes": app_memory_usage,
+        }
+        return app_data
+
     def aggregate(self, applications: List[Application], associations: Dict[str, List[dict]]) -> List[dict]:
         payload = []
         for app in applications:
             app.containers = associations.get(app.id, [])
-            payload.append(asdict(app))
-        payload.sort(key=lambda item: item["name"].lower())
-        payload.append(
+            payload.append(self._with_usage(asdict(app)))
+
+        unassigned = self._with_usage(
             {
                 "id": "unassigned",
                 "name": "Unassigned Containers",
@@ -299,6 +336,16 @@ class ApplicationAggregationService:
                 "lastScanTimestamp": datetime.now(timezone.utc).isoformat(),
             }
         )
+
+        payload.append(unassigned)
+
+        total_cpu = sum((item.get("resourceUsage") or {}).get("cpuPercent", 0.0) for item in payload)
+        for item in payload:
+            app_cpu = (item.get("resourceUsage") or {}).get("cpuPercent", 0.0)
+            share = (app_cpu / total_cpu * 100.0) if total_cpu > 0 else 0.0
+            item["resourceUsage"]["sharePercent"] = round(share, 2)
+
+        payload.sort(key=lambda item: (item.get("resourceUsage", {}).get("sharePercent", 0.0), item.get("name", "").lower()), reverse=True)
         return payload
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   frontend:
     image: node:18
@@ -16,6 +14,9 @@ services:
     volumes:
       - ./backend:/app
       - /var/run/docker.sock:/var/run/docker.sock
+      - /opt:/opt:ro
+      - /srv:/srv:ro
+      - /var/www:/var/www:ro
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
     ports:
       - "${BACKEND_PORT:-8000}:8000"

--- a/frontend/pages/api/applications/[id]/git-status.js
+++ b/frontend/pages/api/applications/[id]/git-status.js
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  const { id } = req.query;
+  const port = process.env.BACKEND_PORT || '8000';
+  const devUrl = `http://localhost:${port}`;
+  const inDocker = fs.existsSync('/.dockerenv');
+  const backendUrl =
+    process.env.BACKEND_URL ||
+    (!inDocker && process.env.NODE_ENV === 'development' ? devUrl : 'http://backend:8000');
+
+  try {
+    const response = await fetch(`${backendUrl}/api/applications/${id}/git-status`);
+    const text = await response.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { error: text };
+    }
+    res.status(response.status).json(data);
+  } catch (err) {
+    console.error('Proxy error:', err);
+    res.status(500).json({ error: 'Failed to fetch git status' });
+  }
+}

--- a/frontend/pages/api/applications/[id]/index.js
+++ b/frontend/pages/api/applications/[id]/index.js
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  const { id } = req.query;
+  const port = process.env.BACKEND_PORT || '8000';
+  const devUrl = `http://localhost:${port}`;
+  const inDocker = fs.existsSync('/.dockerenv');
+  const backendUrl =
+    process.env.BACKEND_URL ||
+    (!inDocker && process.env.NODE_ENV === 'development' ? devUrl : 'http://backend:8000');
+
+  try {
+    const response = await fetch(`${backendUrl}/api/applications/${id}`);
+    const text = await response.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { error: text };
+    }
+    res.status(response.status).json(data);
+  } catch (err) {
+    console.error('Proxy error:', err);
+    res.status(500).json({ error: 'Failed to fetch application' });
+  }
+}

--- a/frontend/pages/api/applications/index.js
+++ b/frontend/pages/api/applications/index.js
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+  const port = process.env.BACKEND_PORT || '8000';
+  const devUrl = `http://localhost:${port}`;
+  const inDocker = fs.existsSync('/.dockerenv');
+  const backendUrl =
+    process.env.BACKEND_URL ||
+    (!inDocker && process.env.NODE_ENV === 'development' ? devUrl : 'http://backend:8000');
+
+  try {
+    const response = await fetch(`${backendUrl}/api/applications`);
+    const text = await response.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { error: text };
+    }
+    res.status(response.status).json(data);
+  } catch (err) {
+    console.error('Proxy error:', err);
+    res.status(500).json({ error: 'Failed to fetch applications' });
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -11,20 +11,22 @@ const HighlightContext = createContext(null);
 
 function ApplicationNode({ data }) {
   return (
-    <div className="bg-slate-900 text-white rounded shadow px-4 py-3 w-[760px] border border-slate-700">
-      <div className="flex items-center justify-between gap-2">
-        <h3 className="font-semibold text-sm truncate" title={data.name}>{data.name}</h3>
-        <span className="text-[10px] uppercase tracking-wide bg-slate-700 px-2 py-0.5 rounded">{data.containerCount} containers</span>
-      </div>
-      {data.path && <div className="text-xs text-slate-300 truncate mt-1" title={data.path}>{data.path}</div>}
-      {(data.description || data.summary) && (
-        <p className="text-xs text-slate-200 mt-2 line-clamp-2">{data.description || data.summary}</p>
-      )}
-      {(data.gitBranch || data.gitCommit) && (
-        <div className="text-[11px] text-slate-300 mt-2">
-          {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}
+    <div className="bg-slate-950/60 border-2 border-slate-700 rounded-lg shadow-sm" style={{ width: data.width, height: data.height }}>
+      <div className="px-4 pt-3 pb-2">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="font-semibold text-sm truncate text-white" title={data.name}>{data.name}</h3>
+          <span className="text-[10px] uppercase tracking-wide bg-slate-700 text-white px-2 py-0.5 rounded">{data.containerCount} containers</span>
         </div>
-      )}
+        {data.path && <div className="text-xs text-slate-300 truncate mt-1" title={data.path}>{data.path}</div>}
+        {(data.description || data.summary) && (
+          <p className="text-xs text-slate-200 mt-2 line-clamp-2">{data.description || data.summary}</p>
+        )}
+        {(data.gitBranch || data.gitCommit) && (
+          <div className="text-[11px] text-slate-300 mt-2">
+            {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -96,6 +98,9 @@ const PORT_SECTION_PADDING = 12;
 const ROW_VERTICAL_GAP = 60;
 const APP_HEADER_HEIGHT = 120;
 const NODE_WIDTH = 192;
+const HORIZONTAL_GAP = 28;
+const GROUP_PADDING = 20;
+const APP_MIN_WIDTH = 780;
 
 function estimateNodeHeight(container) {
   const portCount = container?.ports?.length || 0;
@@ -129,27 +134,43 @@ export default function Home() {
       let currentY = 40;
 
       data.forEach((app) => {
+        const appContainers = app.containers || [];
+        const containerCount = appContainers.length;
+        const calculatedWidth = Math.max(
+          APP_MIN_WIDTH,
+          GROUP_PADDING * 2 + Math.max(1, containerCount) * NODE_WIDTH + Math.max(0, containerCount - 1) * HORIZONTAL_GAP
+        );
+
+        let tallestContainer = BASE_NODE_HEIGHT;
+        appContainers.forEach((container) => {
+          tallestContainer = Math.max(tallestContainer, estimateNodeHeight(container));
+        });
+
+        const appHeight = APP_HEADER_HEIGHT + GROUP_PADDING + tallestContainer + GROUP_PADDING;
+
         mapped.push({
           id: `app-${app.id}`,
           type: 'application',
           position: { x: 40, y: currentY },
           data: {
             ...app,
-            containerCount: app.containers?.length || 0,
+            containerCount,
+            width: calculatedWidth,
+            height: appHeight,
           },
           draggable: false,
           selectable: false,
         });
 
-        let rowMaxHeight = APP_HEADER_HEIGHT;
-        const appContainers = app.containers || [];
+        let rowMaxHeight = appHeight;
         appContainers.forEach((c, i) => {
-          const estimatedHeight = estimateNodeHeight(c);
-          rowMaxHeight = Math.max(rowMaxHeight, estimatedHeight + APP_HEADER_HEIGHT);
           mapped.push({
             id: c.id,
             type: 'container',
-            position: { x: 40 + i * 220, y: currentY + APP_HEADER_HEIGHT },
+            position: {
+              x: 40 + GROUP_PADDING + i * (NODE_WIDTH + HORIZONTAL_GAP),
+              y: currentY + APP_HEADER_HEIGHT + GROUP_PADDING,
+            },
             data: {
               ...c,
               containerId: c.id,

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -22,6 +22,19 @@ function normalizeGitRemoteUrl(remoteUrl) {
   return remoteUrl;
 }
 
+
+function formatBytes(bytes) {
+  if (!bytes) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let size = bytes;
+  let idx = 0;
+  while (size >= 1024 && idx < units.length - 1) {
+    size /= 1024;
+    idx += 1;
+  }
+  return `${size.toFixed(size >= 10 || idx === 0 ? 0 : 1)} ${units[idx]}`;
+}
+
 function UsagePie({ sharePercent }) {
   const safePercent = Number.isFinite(sharePercent) ? Math.max(0, Math.min(100, sharePercent)) : 0;
   const style = {
@@ -52,16 +65,25 @@ function ApplicationNode({ data }) {
               </a>
             )}
           </div>
-          <div className="flex flex-col items-end gap-1">
+          <div className="flex items-start gap-2">
             <UsagePie sharePercent={data.resourceUsage?.sharePercent || 0} />
-            <span className="text-[10px] uppercase tracking-wide bg-slate-700 text-white px-2 py-0.5 rounded">{data.containerCount} containers</span>
-            <button
-              type="button"
-              onClick={data.onToggleCollapse}
-              className="text-[10px] uppercase tracking-wide bg-slate-600 hover:bg-slate-500 text-white px-2 py-0.5 rounded"
-            >
-              {data.collapsed ? 'Expand' : 'Collapse'}
-            </button>
+            <div className="flex flex-col items-end gap-1">
+              <div className="text-[10px] leading-tight text-slate-200 text-right">
+                <div>CPU share: {(data.resourceUsage?.sharePercent || 0).toFixed(1)}%</div>
+                <div>CPU app: {(data.resourceUsage?.cpuPercent || 0).toFixed(2)}%</div>
+                <div>Mem app: {formatBytes(data.resourceUsage?.memoryBytes || 0)}</div>
+              </div>
+              <span className="text-[10px] uppercase tracking-wide bg-slate-700 text-white px-2 py-0.5 rounded">{data.containerCount} containers</span>
+              <button
+                type="button"
+                onClick={data.onToggleCollapse}
+                className="nodrag nopan text-white bg-slate-700 hover:bg-slate-600 rounded p-1 leading-none"
+                aria-label={data.collapsed ? 'Expand section' : 'Collapse section'}
+                title={data.collapsed ? 'Expand section' : 'Collapse section'}
+              >
+                <span className={`inline-block transition-transform ${data.collapsed ? '-rotate-90' : 'rotate-0'}`}>▼</span>
+              </button>
+            </div>
           </div>
         </div>
         {(data.gitBranch || data.gitCommit) && (

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -67,15 +67,17 @@ function ApplicationNode({ data }) {
     <div className="bg-slate-950/60 border-2 border-slate-700 rounded-lg shadow-sm" style={{ width: data.width, height: data.height }}>
       <div className="px-4 pt-3 pb-2">
         <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0">
+          <div className="min-w-0 flex-1 pr-2">
             <h3 className="font-semibold text-sm truncate text-white" title={data.name}>{data.name}</h3>
             {data.path && <div className="text-xs text-slate-300 truncate mt-1" title={data.path}>{data.path}</div>}
-            {githubUrl && (
+            {githubUrl ? (
               <a href={githubUrl} target="_blank" rel="noreferrer" className="text-[11px] text-cyan-300 hover:text-cyan-200 underline truncate block mt-1" title={githubUrl}>
                 {githubUrl}
               </a>
+            ) : (
+              <div className="text-[11px] text-slate-400 mt-1">Repository remote unavailable</div>
             )}
-          </div>
+              </div>
           <div className="flex items-start gap-2">
             <UsagePie sharePercent={data.resourceUsage?.sharePercent || 0} />
             <div className="flex flex-col items-end gap-1">
@@ -103,7 +105,6 @@ function ApplicationNode({ data }) {
             {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}
           </div>
         )}
-        {data.description && <p className="text-xs text-slate-200 mt-2 line-clamp-2">{data.description}</p>}
       </div>
     </div>
   );

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -9,23 +9,67 @@ function DockerIcon(props) {
 
 const HighlightContext = createContext(null);
 
+function normalizeGitRemoteUrl(remoteUrl) {
+  if (!remoteUrl) {
+    return null;
+  }
+  if (remoteUrl.startsWith('git@github.com:')) {
+    return `https://github.com/${remoteUrl.replace('git@github.com:', '').replace(/\.git$/, '')}`;
+  }
+  if (remoteUrl.startsWith('https://github.com/') || remoteUrl.startsWith('http://github.com/')) {
+    return remoteUrl.replace(/\.git$/, '');
+  }
+  return remoteUrl;
+}
+
+function UsagePie({ sharePercent }) {
+  const safePercent = Number.isFinite(sharePercent) ? Math.max(0, Math.min(100, sharePercent)) : 0;
+  const style = {
+    background: `conic-gradient(#38bdf8 ${safePercent}%, #1e293b ${safePercent}% 100%)`,
+  };
+  return (
+    <div className="relative w-12 h-12 rounded-full" style={style} title={`Resource share: ${safePercent.toFixed(2)}%`}>
+      <div className="absolute inset-[6px] rounded-full bg-slate-900 flex items-center justify-center text-[10px] text-slate-200">
+        {safePercent.toFixed(0)}%
+      </div>
+    </div>
+  );
+}
+
 function ApplicationNode({ data }) {
+  const githubUrl = normalizeGitRemoteUrl(data.gitRemoteUrl);
+
   return (
     <div className="bg-slate-950/60 border-2 border-slate-700 rounded-lg shadow-sm" style={{ width: data.width, height: data.height }}>
       <div className="px-4 pt-3 pb-2">
-        <div className="flex items-center justify-between gap-2">
-          <h3 className="font-semibold text-sm truncate text-white" title={data.name}>{data.name}</h3>
-          <span className="text-[10px] uppercase tracking-wide bg-slate-700 text-white px-2 py-0.5 rounded">{data.containerCount} containers</span>
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <h3 className="font-semibold text-sm truncate text-white" title={data.name}>{data.name}</h3>
+            {data.path && <div className="text-xs text-slate-300 truncate mt-1" title={data.path}>{data.path}</div>}
+            {githubUrl && (
+              <a href={githubUrl} target="_blank" rel="noreferrer" className="text-[11px] text-cyan-300 hover:text-cyan-200 underline truncate block mt-1" title={githubUrl}>
+                {githubUrl}
+              </a>
+            )}
+          </div>
+          <div className="flex flex-col items-end gap-1">
+            <UsagePie sharePercent={data.resourceUsage?.sharePercent || 0} />
+            <span className="text-[10px] uppercase tracking-wide bg-slate-700 text-white px-2 py-0.5 rounded">{data.containerCount} containers</span>
+            <button
+              type="button"
+              onClick={data.onToggleCollapse}
+              className="text-[10px] uppercase tracking-wide bg-slate-600 hover:bg-slate-500 text-white px-2 py-0.5 rounded"
+            >
+              {data.collapsed ? 'Expand' : 'Collapse'}
+            </button>
+          </div>
         </div>
-        {data.path && <div className="text-xs text-slate-300 truncate mt-1" title={data.path}>{data.path}</div>}
-        {(data.description || data.summary) && (
-          <p className="text-xs text-slate-200 mt-2 line-clamp-2">{data.description || data.summary}</p>
-        )}
         {(data.gitBranch || data.gitCommit) && (
           <div className="text-[11px] text-slate-300 mt-2">
             {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}
           </div>
         )}
+        {data.description && <p className="text-xs text-slate-200 mt-2 line-clamp-2">{data.description}</p>}
       </div>
     </div>
   );
@@ -95,12 +139,12 @@ function ContainerNode({ data }) {
 const BASE_NODE_HEIGHT = 240;
 const PORT_LINE_HEIGHT = 18;
 const PORT_SECTION_PADDING = 12;
-const ROW_VERTICAL_GAP = 60;
+const ROW_VERTICAL_GAP = 40;
 const APP_HEADER_HEIGHT = 120;
 const NODE_WIDTH = 192;
 const HORIZONTAL_GAP = 28;
 const GROUP_PADDING = 20;
-const APP_MIN_WIDTH = 780;
+const APP_MIN_WIDTH = 620;
 
 function estimateNodeHeight(container) {
   const portCount = container?.ports?.length || 0;
@@ -112,6 +156,7 @@ export default function Home() {
   const [nodes, setNodes] = useState([]);
   const [edges, setEdges] = useState([]);
   const [applications, setApplications] = useState([]);
+  const [collapsedApps, setCollapsedApps] = useState({});
   const [actionState, setActionState] = useState({});
   const [logState, setLogState] = useState({ open: false, id: null, name: '', logs: '', error: null, loading: false });
   const [reactFlowInstance, setReactFlowInstance] = useState(null);
@@ -121,6 +166,10 @@ export default function Home() {
 
   const updateActionState = useCallback((id, newState) => {
     setActionState((prev) => ({ ...prev, [id]: { ...prev[id], ...newState } }));
+  }, []);
+
+  const toggleCollapse = useCallback((appId) => {
+    setCollapsedApps((prev) => ({ ...prev, [appId]: !prev[appId] }));
   }, []);
 
   const fetchApplications = useCallback(async () => {
@@ -135,18 +184,22 @@ export default function Home() {
 
       data.forEach((app) => {
         const appContainers = app.containers || [];
+        const collapsed = !!collapsedApps[app.id];
         const containerCount = appContainers.length;
+
         const calculatedWidth = Math.max(
           APP_MIN_WIDTH,
           GROUP_PADDING * 2 + Math.max(1, containerCount) * NODE_WIDTH + Math.max(0, containerCount - 1) * HORIZONTAL_GAP
         );
 
-        let tallestContainer = BASE_NODE_HEIGHT;
-        appContainers.forEach((container) => {
-          tallestContainer = Math.max(tallestContainer, estimateNodeHeight(container));
-        });
-
-        const appHeight = APP_HEADER_HEIGHT + GROUP_PADDING + tallestContainer + GROUP_PADDING;
+        let appHeight = APP_HEADER_HEIGHT + 12;
+        if (!collapsed && containerCount > 0) {
+          let tallestContainer = BASE_NODE_HEIGHT;
+          appContainers.forEach((container) => {
+            tallestContainer = Math.max(tallestContainer, estimateNodeHeight(container));
+          });
+          appHeight = APP_HEADER_HEIGHT + GROUP_PADDING + tallestContainer + GROUP_PADDING;
+        }
 
         mapped.push({
           id: `app-${app.id}`,
@@ -154,46 +207,49 @@ export default function Home() {
           position: { x: 40, y: currentY },
           data: {
             ...app,
+            collapsed,
             containerCount,
             width: calculatedWidth,
             height: appHeight,
+            onToggleCollapse: () => toggleCollapse(app.id),
           },
           draggable: false,
           selectable: false,
         });
 
-        let rowMaxHeight = appHeight;
-        appContainers.forEach((c, i) => {
-          mapped.push({
-            id: c.id,
-            type: 'container',
-            position: {
-              x: 40 + GROUP_PADDING + i * (NODE_WIDTH + HORIZONTAL_GAP),
-              y: currentY + APP_HEADER_HEIGHT + GROUP_PADDING,
-            },
-            data: {
-              ...c,
-              containerId: c.id,
-              onRestart: () => handleAction(c.id, 'restart'),
-              onStop: () => handleAction(c.id, 'stop'),
-              onShowLogs: () => showLogs(c.id, c.name),
-              onDeleteImage: () => handleDeleteImage(c.id),
-              loadingAction: actionState[c.id]?.loadingAction,
-              error: actionState[c.id]?.error,
-            },
+        if (!collapsed) {
+          appContainers.forEach((c, i) => {
+            mapped.push({
+              id: c.id,
+              type: 'container',
+              position: {
+                x: 40 + GROUP_PADDING + i * (NODE_WIDTH + HORIZONTAL_GAP),
+                y: currentY + APP_HEADER_HEIGHT + GROUP_PADDING,
+              },
+              data: {
+                ...c,
+                containerId: c.id,
+                onRestart: () => handleAction(c.id, 'restart'),
+                onStop: () => handleAction(c.id, 'stop'),
+                onShowLogs: () => showLogs(c.id, c.name),
+                onDeleteImage: () => handleDeleteImage(c.id),
+                loadingAction: actionState[c.id]?.loadingAction,
+                error: actionState[c.id]?.error,
+              },
+            });
           });
-        });
 
-        for (let i = 0; i < appContainers.length - 1; i++) {
-          generatedEdges.push({
-            id: `${appContainers[i].id}-${appContainers[i + 1].id}`,
-            source: appContainers[i].id,
-            target: appContainers[i + 1].id,
-            style: { stroke: '#ffd500' },
-          });
+          for (let i = 0; i < appContainers.length - 1; i++) {
+            generatedEdges.push({
+              id: `${appContainers[i].id}-${appContainers[i + 1].id}`,
+              source: appContainers[i].id,
+              target: appContainers[i + 1].id,
+              style: { stroke: '#ffd500' },
+            });
+          }
         }
 
-        currentY += rowMaxHeight + ROW_VERTICAL_GAP;
+        currentY += appHeight + ROW_VERTICAL_GAP;
       });
 
       setNodes(mapped);
@@ -202,7 +258,7 @@ export default function Home() {
       console.error(err);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [actionState]);
+  }, [actionState, collapsedApps, toggleCollapse]);
 
   const allContainers = useMemo(() => applications.flatMap((app) => app.containers || []), [applications]);
 

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -77,7 +77,12 @@ function ApplicationNode({ data }) {
             ) : (
               <div className="text-[11px] text-slate-400 mt-1">Repository remote unavailable</div>
             )}
+            {(data.gitBranch || data.gitCommit) && (
+              <div className="text-[11px] text-slate-300 mt-2">
+                {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}
               </div>
+            )}
+          </div>
           <div className="flex items-start gap-2">
             <UsagePie sharePercent={data.resourceUsage?.sharePercent || 0} />
             <div className="flex flex-col items-end gap-1">
@@ -100,11 +105,6 @@ function ApplicationNode({ data }) {
             </div>
           </div>
         </div>
-        {(data.gitBranch || data.gitCommit) && (
-          <div className="text-[11px] text-slate-300 mt-2">
-            {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}
-          </div>
-        )}
       </div>
     </div>
   );

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -52,6 +52,17 @@ function UsagePie({ sharePercent }) {
 function ApplicationNode({ data }) {
   const githubUrl = normalizeGitRemoteUrl(data.gitRemoteUrl);
 
+  const handleCollapseMouseDown = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const handleCollapseClick = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    data.onToggleCollapse?.();
+  };
+
   return (
     <div className="bg-slate-950/60 border-2 border-slate-700 rounded-lg shadow-sm" style={{ width: data.width, height: data.height }}>
       <div className="px-4 pt-3 pb-2">
@@ -76,7 +87,8 @@ function ApplicationNode({ data }) {
               <span className="text-[10px] uppercase tracking-wide bg-slate-700 text-white px-2 py-0.5 rounded">{data.containerCount} containers</span>
               <button
                 type="button"
-                onClick={data.onToggleCollapse}
+                onMouseDown={handleCollapseMouseDown}
+                onClick={handleCollapseClick}
                 className="nodrag nopan text-white bg-slate-700 hover:bg-slate-600 rounded p-1 leading-none"
                 aria-label={data.collapsed ? 'Expand section' : 'Collapse section'}
                 title={data.collapsed ? 'Expand section' : 'Collapse section'}
@@ -236,7 +248,7 @@ export default function Home() {
             onToggleCollapse: () => toggleCollapse(app.id),
           },
           draggable: false,
-          selectable: false,
+          selectable: true,
         });
 
         if (!collapsed) {

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -9,6 +9,26 @@ function DockerIcon(props) {
 
 const HighlightContext = createContext(null);
 
+function ApplicationNode({ data }) {
+  return (
+    <div className="bg-slate-900 text-white rounded shadow px-4 py-3 w-[760px] border border-slate-700">
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="font-semibold text-sm truncate" title={data.name}>{data.name}</h3>
+        <span className="text-[10px] uppercase tracking-wide bg-slate-700 px-2 py-0.5 rounded">{data.containerCount} containers</span>
+      </div>
+      {data.path && <div className="text-xs text-slate-300 truncate mt-1" title={data.path}>{data.path}</div>}
+      {(data.description || data.summary) && (
+        <p className="text-xs text-slate-200 mt-2 line-clamp-2">{data.description || data.summary}</p>
+      )}
+      {(data.gitBranch || data.gitCommit) && (
+        <div className="text-[11px] text-slate-300 mt-2">
+          {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}
+        </div>
+      )}
+    </div>
+  );
+}
+
 function ContainerNode({ data }) {
   const highlightedContainerId = useContext(HighlightContext);
   const color =
@@ -52,43 +72,18 @@ function ContainerNode({ data }) {
           </div>
         )}
         <div className="flex flex-wrap gap-1 justify-end">
-          <button
-            onClick={data.onRestart}
-            disabled={data.loadingAction === 'restart'}
-            className="bg-blue-500 disabled:opacity-50 text-white rounded px-2 py-1 text-xs !cursor-pointer disabled:!cursor-not-allowed"
-          >
-            {data.loadingAction === 'restart'
-              ? data.status === 'running'
-                ? 'Restarting...'
-                : 'Starting...'
-              : data.status === 'running'
-              ? 'Restart'
-              : 'Start'}
+          <button onClick={data.onRestart} disabled={data.loadingAction === 'restart'} className="bg-blue-500 disabled:opacity-50 text-white rounded px-2 py-1 text-xs !cursor-pointer disabled:!cursor-not-allowed">
+            {data.loadingAction === 'restart' ? (data.status === 'running' ? 'Restarting...' : 'Starting...') : data.status === 'running' ? 'Restart' : 'Start'}
           </button>
-          <button
-            onClick={data.onStop}
-            disabled={data.loadingAction === 'stop'}
-            className="bg-red-500 disabled:opacity-50 text-white rounded px-2 py-1 text-xs !cursor-pointer disabled:!cursor-not-allowed"
-          >
+          <button onClick={data.onStop} disabled={data.loadingAction === 'stop'} className="bg-red-500 disabled:opacity-50 text-white rounded px-2 py-1 text-xs !cursor-pointer disabled:!cursor-not-allowed">
             {data.loadingAction === 'stop' ? 'Stopping...' : 'Stop'}
           </button>
-          <button
-            onClick={data.onShowLogs}
-            className="bg-gray-500 text-white rounded px-2 py-1 text-xs !cursor-pointer"
-          >
-            Logs
-          </button>
-          <button
-            onClick={data.onDeleteImage}
-            disabled={data.loadingAction === 'deleteImage'}
-            className="bg-purple-600 disabled:opacity-50 text-white rounded px-2 py-1 text-xs !cursor-pointer disabled:!cursor-not-allowed"
-          >
+          <button onClick={data.onShowLogs} className="bg-gray-500 text-white rounded px-2 py-1 text-xs !cursor-pointer">Logs</button>
+          <button onClick={data.onDeleteImage} disabled={data.loadingAction === 'deleteImage'} className="bg-purple-600 disabled:opacity-50 text-white rounded px-2 py-1 text-xs !cursor-pointer disabled:!cursor-not-allowed">
             {data.loadingAction === 'deleteImage' ? 'Deleting...' : 'Delete Image'}
           </button>
         </div>
-        {data.error && (
-          <div className="text-red-500 text-xs mt-1 break-all">{data.error}</div>
-        )}
+        {data.error && <div className="text-red-500 text-xs mt-1 break-all">{data.error}</div>}
       </div>
       <span className={`absolute top-2 right-2 w-3 h-3 rounded-full ${color}`}></span>
     </div>
@@ -98,7 +93,8 @@ function ContainerNode({ data }) {
 const BASE_NODE_HEIGHT = 240;
 const PORT_LINE_HEIGHT = 18;
 const PORT_SECTION_PADDING = 12;
-const ROW_VERTICAL_GAP = 8;
+const ROW_VERTICAL_GAP = 60;
+const APP_HEADER_HEIGHT = 120;
 const NODE_WIDTH = 192;
 
 function estimateNodeHeight(container) {
@@ -110,7 +106,7 @@ function estimateNodeHeight(container) {
 export default function Home() {
   const [nodes, setNodes] = useState([]);
   const [edges, setEdges] = useState([]);
-  const [containers, setContainers] = useState([]);
+  const [applications, setApplications] = useState([]);
   const [actionState, setActionState] = useState({});
   const [logState, setLogState] = useState({ open: false, id: null, name: '', logs: '', error: null, loading: false });
   const [reactFlowInstance, setReactFlowInstance] = useState(null);
@@ -119,38 +115,41 @@ export default function Home() {
   const logsIntervalRef = useRef(null);
 
   const updateActionState = useCallback((id, newState) => {
-    setActionState((prev) => ({
-      ...prev,
-      [id]: { ...prev[id], ...newState },
-    }));
+    setActionState((prev) => ({ ...prev, [id]: { ...prev[id], ...newState } }));
   }, []);
 
-  const fetchContainers = useCallback(async () => {
+  const fetchApplications = useCallback(async () => {
     try {
-      const res = await fetch('/api/containers');
+      const res = await fetch('/api/applications');
       const data = await res.json();
-
-      setContainers(data);
-      const groups = {};
-      data.forEach((c) => {
-        const key = c.project || 'default';
-        if (!groups[key]) groups[key] = [];
-        groups[key].push(c);
-      });
+      setApplications(data);
 
       const mapped = [];
+      const generatedEdges = [];
       let currentY = 40;
-      Object.values(groups).forEach((containers) => {
-        let maxHeight = BASE_NODE_HEIGHT;
-        containers.forEach((c, i) => {
+
+      data.forEach((app) => {
+        mapped.push({
+          id: `app-${app.id}`,
+          type: 'application',
+          position: { x: 40, y: currentY },
+          data: {
+            ...app,
+            containerCount: app.containers?.length || 0,
+          },
+          draggable: false,
+          selectable: false,
+        });
+
+        let rowMaxHeight = APP_HEADER_HEIGHT;
+        const appContainers = app.containers || [];
+        appContainers.forEach((c, i) => {
           const estimatedHeight = estimateNodeHeight(c);
-          if (estimatedHeight > maxHeight) {
-            maxHeight = estimatedHeight;
-          }
+          rowMaxHeight = Math.max(rowMaxHeight, estimatedHeight + APP_HEADER_HEIGHT);
           mapped.push({
             id: c.id,
             type: 'container',
-            position: { x: 40 + i * 220, y: currentY },
+            position: { x: 40 + i * 220, y: currentY + APP_HEADER_HEIGHT },
             data: {
               ...c,
               containerId: c.id,
@@ -163,19 +162,17 @@ export default function Home() {
             },
           });
         });
-        currentY += maxHeight + ROW_VERTICAL_GAP;
-      });
 
-      const generatedEdges = [];
-      Object.values(groups).forEach((containers) => {
-        for (let i = 0; i < containers.length - 1; i++) {
+        for (let i = 0; i < appContainers.length - 1; i++) {
           generatedEdges.push({
-            id: `${containers[i].id}-${containers[i + 1].id}`,
-            source: containers[i].id,
-            target: containers[i + 1].id,
+            id: `${appContainers[i].id}-${appContainers[i + 1].id}`,
+            source: appContainers[i].id,
+            target: appContainers[i + 1].id,
             style: { stroke: '#ffd500' },
           });
         }
+
+        currentY += rowMaxHeight + ROW_VERTICAL_GAP;
       });
 
       setNodes(mapped);
@@ -183,17 +180,16 @@ export default function Home() {
     } catch (err) {
       console.error(err);
     }
-  // handleAction, handleDeleteImage and showLogs are defined below and remain stable
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [actionState]);
 
+  const allContainers = useMemo(() => applications.flatMap((app) => app.containers || []), [applications]);
+
   const externalPorts = useMemo(() => {
     const items = [];
-    containers.forEach((container) => {
+    allContainers.forEach((container) => {
       (container.ports || []).forEach((port) => {
-        if (!port.host_port) {
-          return;
-        }
+        if (!port.host_port) return;
         items.push({
           id: `${container.id}-${port.host_ip || 'all'}-${port.host_port}-${port.container_port || 'none'}`,
           containerId: container.id,
@@ -205,87 +201,62 @@ export default function Home() {
       });
     });
     return items;
-  }, [containers]);
+  }, [allContainers]);
 
-  const handleJumpToContainer = useCallback(
-    (containerId) => {
-      if (!reactFlowInstance || typeof reactFlowInstance.setCenter !== 'function') {
+  const handleJumpToContainer = useCallback((containerId) => {
+    if (!reactFlowInstance || typeof reactFlowInstance.setCenter !== 'function') return;
+    const node = nodes.find((n) => n.id === containerId);
+    const container = allContainers.find((c) => c.id === containerId);
+    if (!node) return;
+    const estimatedHeight = container ? estimateNodeHeight(container) : BASE_NODE_HEIGHT;
+    reactFlowInstance.setCenter(node.position.x + NODE_WIDTH / 2, node.position.y + estimatedHeight / 2, { duration: 800, zoom: 1 });
+    if (highlightTimeoutRef.current) clearTimeout(highlightTimeoutRef.current);
+    setHighlightedContainerId(containerId);
+    highlightTimeoutRef.current = setTimeout(() => setHighlightedContainerId(null), 2000);
+  }, [allContainers, nodes, reactFlowInstance]);
+
+  const handleAction = useCallback(async (id, action) => {
+    updateActionState(id, { loadingAction: action, error: null });
+    try {
+      const res = await fetch(`/api/containers/${id}/${action}`, { method: 'POST' });
+      if (!res.ok) {
+        let msg = res.statusText;
+        try {
+          const data = await res.json();
+          msg = data.error || JSON.stringify(data);
+        } catch {}
+        updateActionState(id, { loadingAction: null, error: msg });
         return;
       }
-      const node = nodes.find((n) => n.id === containerId);
-      const container = containers.find((c) => c.id === containerId);
-      if (!node) {
+      updateActionState(id, { loadingAction: null, error: null });
+      fetchApplications();
+    } catch (err) {
+      updateActionState(id, { loadingAction: null, error: err.message });
+    }
+  }, [fetchApplications, updateActionState]);
+
+  const handleDeleteImage = useCallback(async (id) => {
+    updateActionState(id, { loadingAction: 'deleteImage', error: null });
+    try {
+      const res = await fetch(`/api/containers/${id}/delete-image`, { method: 'DELETE' });
+      if (!res.ok) {
+        let msg = res.statusText;
+        try {
+          const data = await res.json();
+          msg = data.error || JSON.stringify(data);
+        } catch {}
+        updateActionState(id, { loadingAction: null, error: msg });
         return;
       }
-      const estimatedHeight = container ? estimateNodeHeight(container) : BASE_NODE_HEIGHT;
-      const centerX = node.position.x + NODE_WIDTH / 2;
-      const centerY = node.position.y + estimatedHeight / 2;
-      reactFlowInstance.setCenter(centerX, centerY, { duration: 800, zoom: 1 });
-      if (highlightTimeoutRef.current) {
-        clearTimeout(highlightTimeoutRef.current);
-      }
-      setHighlightedContainerId(containerId);
-      highlightTimeoutRef.current = setTimeout(() => {
-        setHighlightedContainerId(null);
-      }, 2000);
-    },
-    [containers, nodes, reactFlowInstance]
-  );
-
-  const handleAction = useCallback(
-    async (id, action) => {
-      updateActionState(id, { loadingAction: action, error: null });
-      try {
-        const res = await fetch(`/api/containers/${id}/${action}`, {
-          method: 'POST',
-        });
-        if (!res.ok) {
-          let msg = res.statusText;
-          try {
-            const data = await res.json();
-            msg = data.error || JSON.stringify(data);
-          } catch {}
-          updateActionState(id, { loadingAction: null, error: msg });
-          return;
-        }
-        updateActionState(id, { loadingAction: null, error: null });
-        fetchContainers();
-      } catch (err) {
-        updateActionState(id, { loadingAction: null, error: err.message });
-      }
-    },
-    [fetchContainers, updateActionState]
-  );
-
-  const handleDeleteImage = useCallback(
-    async (id) => {
-      updateActionState(id, { loadingAction: 'deleteImage', error: null });
-      try {
-        const res = await fetch(`/api/containers/${id}/delete-image`, {
-          method: 'DELETE',
-        });
-        if (!res.ok) {
-          let msg = res.statusText;
-          try {
-            const data = await res.json();
-            msg = data.error || JSON.stringify(data);
-          } catch {}
-          updateActionState(id, { loadingAction: null, error: msg });
-          return;
-        }
-        updateActionState(id, { loadingAction: null, error: null });
-        fetchContainers();
-      } catch (err) {
-        updateActionState(id, { loadingAction: null, error: err.message });
-      }
-    },
-    [fetchContainers, updateActionState]
-  );
+      updateActionState(id, { loadingAction: null, error: null });
+      fetchApplications();
+    } catch (err) {
+      updateActionState(id, { loadingAction: null, error: err.message });
+    }
+  }, [fetchApplications, updateActionState]);
 
   const fetchLogsForContainer = useCallback(async (id) => {
-    if (!id) {
-      return;
-    }
+    if (!id) return;
     try {
       const res = await fetch(`/api/containers/${id}/logs`);
       if (!res.ok) {
@@ -304,13 +275,10 @@ export default function Home() {
     }
   }, []);
 
-  const showLogs = useCallback(
-    async (id, name) => {
-      setLogState({ open: true, id, name, logs: '', error: null, loading: true });
-      fetchLogsForContainer(id);
-    },
-    [fetchLogsForContainer]
-  );
+  const showLogs = useCallback(async (id, name) => {
+    setLogState({ open: true, id, name, logs: '', error: null, loading: true });
+    fetchLogsForContainer(id);
+  }, [fetchLogsForContainer]);
 
   const closeLogs = useCallback(() => {
     if (logsIntervalRef.current) {
@@ -320,9 +288,7 @@ export default function Home() {
     setLogState({ open: false, id: null, name: '', logs: '', error: null, loading: false });
   }, []);
 
-  useEffect(() => {
-    fetchContainers();
-  }, [fetchContainers]);
+  useEffect(() => { fetchApplications(); }, [fetchApplications]);
 
   useEffect(() => {
     if (!logState.open || !logState.id) {
@@ -332,15 +298,8 @@ export default function Home() {
       }
       return;
     }
-
-    if (logsIntervalRef.current) {
-      clearInterval(logsIntervalRef.current);
-    }
-
-    logsIntervalRef.current = setInterval(() => {
-      fetchLogsForContainer(logState.id);
-    }, 3000);
-
+    if (logsIntervalRef.current) clearInterval(logsIntervalRef.current);
+    logsIntervalRef.current = setInterval(() => fetchLogsForContainer(logState.id), 3000);
     return () => {
       if (logsIntervalRef.current) {
         clearInterval(logsIntervalRef.current);
@@ -349,16 +308,9 @@ export default function Home() {
     };
   }, [fetchLogsForContainer, logState.id, logState.open]);
 
-  useEffect(() => {
-    return () => {
-      if (highlightTimeoutRef.current) {
-        clearTimeout(highlightTimeoutRef.current);
-      }
-      if (logsIntervalRef.current) {
-        clearInterval(logsIntervalRef.current);
-        logsIntervalRef.current = null;
-      }
-    };
+  useEffect(() => () => {
+    if (highlightTimeoutRef.current) clearTimeout(highlightTimeoutRef.current);
+    if (logsIntervalRef.current) clearInterval(logsIntervalRef.current);
   }, []);
 
   return (
@@ -368,7 +320,7 @@ export default function Home() {
           <ReactFlow
             nodes={nodes}
             edges={edges}
-            nodeTypes={{ container: ContainerNode }}
+            nodeTypes={{ container: ContainerNode, application: ApplicationNode }}
             proOptions={{}}
             nodesDraggable={false}
             onInit={setReactFlowInstance}
@@ -381,37 +333,21 @@ export default function Home() {
       <aside className="w-72 border-l border-gray-200 bg-white text-black overflow-y-auto p-4 space-y-3">
         <div>
           <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-700">External Ports</h2>
-          <p className="text-[11px] text-gray-500 mt-1">
-            Double-click a port or use Focus to center its container
-          </p>
+          <p className="text-[11px] text-gray-500 mt-1">Double-click a port or use Focus to center its container</p>
         </div>
-        {externalPorts.length === 0 ? (
-          <p className="text-xs text-gray-500">No external ports available.</p>
-        ) : (
+        {externalPorts.length === 0 ? <p className="text-xs text-gray-500">No external ports available.</p> : (
           <ul className="space-y-2 text-xs">
             {externalPorts.map((port) => {
               const hostLabel = port.hostIp && port.hostIp !== '::' ? `${port.hostIp}:${port.hostPort}` : port.hostPort;
               return (
                 <li key={port.id} className="bg-gray-100 rounded px-2 py-2">
-                  <div
-                    onDoubleClick={() => handleJumpToContainer(port.containerId)}
-                    className="flex items-start gap-2"
-                    title={`Container: ${port.containerName}\nInternal: ${port.containerPort || 'unknown'}`}
-                  >
+                  <div onDoubleClick={() => handleJumpToContainer(port.containerId)} className="flex items-start gap-2" title={`Container: ${port.containerName}\nInternal: ${port.containerPort || 'unknown'}`}>
                     <div className="flex-1 min-w-0">
                       <div className="font-semibold truncate">{hostLabel}</div>
                       <div className="text-gray-600 truncate">{port.containerName}</div>
-                      {port.containerPort && (
-                        <div className="text-gray-500 truncate text-[11px]">Internal: {port.containerPort}</div>
-                      )}
+                      {port.containerPort && <div className="text-gray-500 truncate text-[11px]">Internal: {port.containerPort}</div>}
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => handleJumpToContainer(port.containerId)}
-                      className="shrink-0 bg-blue-500 hover:bg-blue-600 text-white rounded px-2 py-1 text-[11px] uppercase"
-                    >
-                      Focus
-                    </button>
+                    <button type="button" onClick={() => handleJumpToContainer(port.containerId)} className="shrink-0 bg-blue-500 hover:bg-blue-600 text-white rounded px-2 py-1 text-[11px] uppercase">Focus</button>
                   </div>
                 </li>
               );
@@ -426,13 +362,7 @@ export default function Home() {
               <h2 className="font-semibold text-sm">Logs for {logState.name || logState.id}</h2>
               <button onClick={closeLogs} className="bg-blue-500 text-white rounded px-2 py-1 text-xs !cursor-pointer">Close</button>
             </div>
-            {logState.loading ? (
-              <p className="text-sm">Loading...</p>
-            ) : logState.error ? (
-              <p className="text-red-500 text-sm break-all">{logState.error}</p>
-            ) : (
-              <pre className="text-xs whitespace-pre-wrap break-all">{logState.logs}</pre>
-            )}
+            {logState.loading ? <p className="text-sm">Loading...</p> : logState.error ? <p className="text-red-500 text-sm break-all">{logState.error}</p> : <pre className="text-xs whitespace-pre-wrap break-all">{logState.logs}</pre>}
           </div>
         </div>
       )}
@@ -443,9 +373,7 @@ export default function Home() {
 export async function getServerSideProps(context) {
   const session = await getSession(context);
   if (!session) {
-    return {
-      redirect: { destination: '/login', permanent: false },
-    };
+    return { redirect: { destination: '/login', permanent: false } };
   }
   return { props: {} };
 }


### PR DESCRIPTION
### Motivation
- Make the dashboard application-aware by discovering projects on disk and grouping containers by application while preserving existing container card behavior.
- Enrich each application with Git and project metadata and expose project-level APIs without changing existing container endpoints or UI card internals.
- Provide a resilient, non-blocking background scanner to keep application metadata and associations up to date.

### Description
- Add a new domain layer and services in `backend/services.py` including `Application`, `DockerService`, `GitMetadataService`, `ApplicationDiscoveryService`, `ContainerAssociationService`, `ApplicationAggregationService`, and an `ApplicationRegistry` to hold scan results.
- Add configuration support via `backend/config.py` with a default `backend/config.yml` and environment overrides for `scanPaths` and `scanIntervalSeconds`, and add `pyyaml` to `backend/requirements.txt`.
- Wire a non-blocking background scanner into `backend/main.py` that runs on startup, rescans at the configured interval, updates Git metadata, and rebuilds container-to-application associations, and add new endpoints `GET /api/applications`, `GET /api/applications/{id}`, and `GET /api/applications/{id}/git-status`.
- Add Next.js proxy routes in `frontend/pages/api/applications/*` to keep frontend auth and proxy behavior consistent, and update `frontend/pages/index.js` to render `ApplicationNode` headers and group existing container cards under each application (including an `Unassigned Containers` group) while leaving container card behavior unchanged.
- Document the new application-aware configuration and endpoints in `README.md`.

### Testing
- Ran `python -m py_compile backend/main.py backend/services.py backend/config.py` and it completed successfully, confirming Python syntax correctness.
- Ran `cd frontend && npm run lint` and the linter passed (Next.js produced a non-failing `<img>` optimization warning but no errors).
- Launched the frontend with `cd frontend && npm run dev` for visual validation and captured a screenshot of the updated dashboard successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a755bf1d0832ca7953a5e5604e795)