### PR TITLE
Update project section palette and add memory share indicator

### DIFF
--- a/backend/services.py
+++ b/backend/services.py
@@ -340,10 +340,15 @@ class ApplicationAggregationService:
         payload.append(unassigned)
 
         total_cpu = sum((item.get("resourceUsage") or {}).get("cpuPercent", 0.0) for item in payload)
+        total_memory = sum((item.get("resourceUsage") or {}).get("memoryBytes", 0) for item in payload)
         for item in payload:
-            app_cpu = (item.get("resourceUsage") or {}).get("cpuPercent", 0.0)
-            share = (app_cpu / total_cpu * 100.0) if total_cpu > 0 else 0.0
-            item["resourceUsage"]["sharePercent"] = round(share, 2)
+            usage = item.get("resourceUsage") or {}
+            app_cpu = usage.get("cpuPercent", 0.0)
+            app_memory = usage.get("memoryBytes", 0)
+            cpu_share = (app_cpu / total_cpu * 100.0) if total_cpu > 0 else 0.0
+            memory_share = (app_memory / total_memory * 100.0) if total_memory > 0 else 0.0
+            item["resourceUsage"]["sharePercent"] = round(cpu_share, 2)
+            item["resourceUsage"]["memorySharePercent"] = round(memory_share, 2)
 
         payload.sort(key=lambda item: (item.get("resourceUsage", {}).get("sharePercent", 0.0), item.get("name", "").lower()), reverse=True)
         return payload

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -37,12 +37,11 @@ function formatBytes(bytes) {
 
 function UsagePie({ label, sharePercent }) {
   const safePercent = Number.isFinite(sharePercent) ? Math.max(0, Math.min(100, sharePercent)) : 0;
-  const orangeStop = safePercent * 0.6;
   const style = {
     background:
       safePercent <= 0
         ? '#1a1a1a'
-        : `conic-gradient(#facc15 0%, #f97316 ${orangeStop}%, #dc2626 ${safePercent}%, #1a1a1a ${safePercent}%, #1a1a1a 100%)`,
+        : `conic-gradient(from -90deg, transparent 0% ${safePercent}%, #1a1a1a ${safePercent}% 100%), conic-gradient(from -90deg, #facc15 0%, #facc15 70%, #f97316 88%, #dc2626 100%)`,
   };
   return (
     <div className="flex flex-col items-center gap-1" title={`${label}: ${safePercent.toFixed(2)}%`}>

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -35,16 +35,19 @@ function formatBytes(bytes) {
   return `${size.toFixed(size >= 10 || idx === 0 ? 0 : 1)} ${units[idx]}`;
 }
 
-function UsagePie({ sharePercent }) {
+function UsagePie({ label, sharePercent }) {
   const safePercent = Number.isFinite(sharePercent) ? Math.max(0, Math.min(100, sharePercent)) : 0;
   const style = {
-    background: `conic-gradient(#38bdf8 ${safePercent}%, #1e293b ${safePercent}% 100%)`,
+    background: `conic-gradient(from -90deg, #facc15 0%, #f97316 60%, #dc2626 ${safePercent}%, #1a1a1a ${safePercent}% 100%)`,
   };
   return (
-    <div className="relative w-12 h-12 rounded-full" style={style} title={`Resource share: ${safePercent.toFixed(2)}%`}>
-      <div className="absolute inset-[6px] rounded-full bg-slate-900 flex items-center justify-center text-[10px] text-slate-200">
-        {safePercent.toFixed(0)}%
+    <div className="flex flex-col items-center gap-1" title={`${label}: ${safePercent.toFixed(2)}%`}>
+      <div className="relative w-12 h-12 rounded-full" style={style}>
+        <div className="absolute inset-[6px] rounded-full bg-black flex items-center justify-center text-[10px] text-yellow-100">
+          {safePercent.toFixed(0)}%
+        </div>
       </div>
+      <span className="text-[9px] uppercase tracking-wide text-yellow-200">{label}</span>
     </div>
   );
 }
@@ -64,39 +67,41 @@ function ApplicationNode({ data }) {
   };
 
   return (
-    <div className="bg-slate-950/60 border-2 border-slate-700 rounded-lg shadow-sm" style={{ width: data.width, height: data.height }}>
+    <div className="bg-black/80 border-2 border-yellow-500 rounded-lg shadow-sm" style={{ width: data.width, height: data.height }}>
       <div className="px-4 pt-3 pb-2">
         <div className="flex items-start justify-between gap-2">
           <div className="min-w-0 flex-1 pr-2">
-            <h3 className="font-semibold text-sm truncate text-white" title={data.name}>{data.name}</h3>
-            {data.path && <div className="text-xs text-slate-300 truncate mt-1" title={data.path}>{data.path}</div>}
+            <h3 className="font-semibold text-sm truncate text-yellow-100" title={data.name}>{data.name}</h3>
+            {data.path && <div className="text-xs text-yellow-200/80 truncate mt-1" title={data.path}>{data.path}</div>}
             {githubUrl ? (
-              <a href={githubUrl} target="_blank" rel="noreferrer" className="text-[11px] text-cyan-300 hover:text-cyan-200 underline truncate block mt-1" title={githubUrl}>
+              <a href={githubUrl} target="_blank" rel="noreferrer" className="text-[11px] text-yellow-300 hover:text-yellow-200 underline truncate block mt-1" title={githubUrl}>
                 {githubUrl}
               </a>
             ) : (
-              <div className="text-[11px] text-slate-400 mt-1">Repository remote unavailable</div>
+              <div className="text-[11px] text-yellow-200/70 mt-1">Repository remote unavailable</div>
             )}
             {(data.gitBranch || data.gitCommit) && (
-              <div className="text-[11px] text-slate-300 mt-2">
+              <div className="text-[11px] text-yellow-100/90 mt-2">
                 {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}
               </div>
             )}
           </div>
           <div className="flex items-start gap-2">
-            <UsagePie sharePercent={data.resourceUsage?.sharePercent || 0} />
+            <UsagePie label="CPU" sharePercent={data.resourceUsage?.sharePercent || 0} />
+            <UsagePie label="MEM" sharePercent={data.resourceUsage?.memorySharePercent || 0} />
             <div className="flex flex-col items-end gap-1">
-              <div className="text-[10px] leading-tight text-slate-200 text-right">
+              <div className="text-[10px] leading-tight text-yellow-100/90 text-right">
                 <div>CPU share: {(data.resourceUsage?.sharePercent || 0).toFixed(1)}%</div>
+                <div>Mem share: {(data.resourceUsage?.memorySharePercent || 0).toFixed(1)}%</div>
                 <div>CPU app: {(data.resourceUsage?.cpuPercent || 0).toFixed(2)}%</div>
                 <div>Mem app: {formatBytes(data.resourceUsage?.memoryBytes || 0)}</div>
               </div>
-              <span className="text-[10px] uppercase tracking-wide bg-slate-700 text-white px-2 py-0.5 rounded">{data.containerCount} containers</span>
+              <span className="text-[10px] uppercase tracking-wide bg-yellow-500 text-black px-2 py-0.5 rounded">{data.containerCount} containers</span>
               <button
                 type="button"
                 onMouseDown={handleCollapseMouseDown}
                 onClick={handleCollapseClick}
-                className="nodrag nopan text-white bg-slate-700 hover:bg-slate-600 rounded p-1 leading-none"
+                className="nodrag nopan text-black bg-yellow-500 hover:bg-yellow-400 rounded p-1 leading-none"
                 aria-label={data.collapsed ? 'Expand section' : 'Collapse section'}
                 title={data.collapsed ? 'Expand section' : 'Collapse section'}
               >

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -41,7 +41,7 @@ function UsagePie({ label, sharePercent }) {
     background:
       safePercent <= 0
         ? '#1a1a1a'
-        : `conic-gradient(from -90deg, transparent 0% ${safePercent}%, #1a1a1a ${safePercent}% 100%), conic-gradient(from -90deg, #facc15 0%, #facc15 70%, #f97316 88%, #dc2626 100%)`,
+        : `conic-gradient(transparent 0% ${safePercent}%, #1a1a1a ${safePercent}% 100%), conic-gradient(#facc15 0%, #f59e0b 35%, #ef4444 55%, #b91c1c 100%)`,
   };
   return (
     <div className="flex flex-col items-center gap-1" title={`${label}: ${safePercent.toFixed(2)}%`}>

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -37,8 +37,12 @@ function formatBytes(bytes) {
 
 function UsagePie({ label, sharePercent }) {
   const safePercent = Number.isFinite(sharePercent) ? Math.max(0, Math.min(100, sharePercent)) : 0;
+  const orangeStop = safePercent * 0.6;
   const style = {
-    background: `conic-gradient(from -90deg, #facc15 0%, #f97316 60%, #dc2626 ${safePercent}%, #1a1a1a ${safePercent}% 100%)`,
+    background:
+      safePercent <= 0
+        ? '#1a1a1a'
+        : `conic-gradient(#facc15 0%, #f97316 ${orangeStop}%, #dc2626 ${safePercent}%, #1a1a1a ${safePercent}%, #1a1a1a 100%)`,
   };
   return (
     <div className="flex flex-col items-center gap-1" title={`${label}: ${safePercent.toFixed(2)}%`}>


### PR DESCRIPTION
### Motivation
- Replace the bluish/transparent project fieldset visual with a clear yellow + black palette so project sections are visually consistent and legible. 
- Provide an additional memory-specific usage ring alongside the existing CPU ring and use a yellow→orange→red gradient to indicate increasing usage severity.

### Description
- Frontend (`frontend/pages/index.js`): updated `UsagePie` to accept a `label` and render a conic gradient (`#facc15 → #f97316 → #dc2626`) that fills by percent, added visible label text, and adjusted inner dial colors for yellow/black contrast.  
- Frontend (`frontend/pages/index.js`): added a second `UsagePie` instance for memory (`MEM`) and updated the application header to show both `CPU` and `MEM` rings with textual `Mem share` and `Mem app` values; switched application wrapper styling to `bg-black/80` with `border-yellow-500` and updated title/path/github text, container-count badge, and collapse button to yellow-themed classes.  
- Backend (`backend/services.py`): compute total memory and per-application `memorySharePercent` alongside existing CPU share so the frontend can display consistent memory share percentages.  
- Kept individual container card layout and control buttons unchanged as requested.

### Testing
- Ran `python -m py_compile backend/services.py` and it completed successfully.  
- Ran `npm --prefix frontend run lint` which completed with a Next.js image-element warning but no blocking errors.  
- Started the frontend (`npm --prefix frontend run dev`) and executed an automated Playwright script to authenticate and capture a screenshot, which produced the artifact at `browser:/tmp/codex_browser_invocations/7c6f4d3f140b030c/artifacts/artifacts/index-after-theme.png`, however the local backend was unreachable during that run (`ECONNREFUSED 127.0.0.1:8000`) so application/container data did not load in the screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bc4b74d7c832ca56b7f95f6e65353)