### PR TITLE
Add per-project branch dropdown with refresh and git pull support

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -166,3 +166,36 @@ async def get_application_git_status(application_id: str):
         raise HTTPException(status_code=400, detail="Application has no filesystem path")
 
     return await asyncio.to_thread(git_metadata_service.get_git_status, Path(path))
+
+
+@app.get("/api/applications/{application_id}/branches")
+async def get_application_branches(application_id: str):
+    app_data = await application_registry.get_application(application_id)
+    if not app_data:
+        raise HTTPException(status_code=404, detail="Application not found")
+    path = app_data.get("path")
+    if not path:
+        raise HTTPException(status_code=400, detail="Application has no filesystem path")
+
+    return await asyncio.to_thread(git_metadata_service.list_active_branches, Path(path))
+
+
+@app.post("/api/applications/{application_id}/pull")
+async def pull_application_branch(application_id: str, payload: dict):
+    app_data = await application_registry.get_application(application_id)
+    if not app_data:
+        raise HTTPException(status_code=404, detail="Application not found")
+    path = app_data.get("path")
+    if not path:
+        raise HTTPException(status_code=400, detail="Application has no filesystem path")
+
+    result = await asyncio.to_thread(
+        git_metadata_service.pull_branch,
+        Path(path),
+        str(payload.get("branch") or "").strip(),
+    )
+
+    if not result.get("ok"):
+        raise HTTPException(status_code=400, detail=result.get("error") or "Pull failed")
+
+    return result

--- a/backend/services.py
+++ b/backend/services.py
@@ -210,6 +210,23 @@ class GitMetadataService:
                     "error": err or f"Failed to switch from {active_branch or 'unknown'} to {selected_branch}.",
                 }
 
+        local_commit = self._run_git(["rev-parse", "HEAD"], path)
+        remote_heads = self._run_git(["ls-remote", "--heads", "origin", selected_branch], path)
+        remote_commit = None
+        if remote_heads:
+            first_line = remote_heads.splitlines()[0]
+            pieces = first_line.split()
+            if pieces:
+                remote_commit = pieces[0].strip() or None
+
+        if local_commit and remote_commit and local_commit == remote_commit:
+            return {
+                "ok": True,
+                "branch": selected_branch,
+                "commit": local_commit,
+                "output": "Already up to date.",
+            }
+
         ok, out, err = self._run_git_with_result(
             ["pull", "--no-write-fetch-head", "origin", selected_branch],
             path,

--- a/backend/services.py
+++ b/backend/services.py
@@ -178,11 +178,17 @@ class GitMetadataService:
 
     def list_active_branches(self, path: Path) -> dict:
         current_branch = self._run_git(["rev-parse", "--abbrev-ref", "HEAD"], path)
-        branches_output = self._run_git(["for-each-ref", "--format=%(refname:short)", "refs/heads"], path)
+        branches_output = self._run_git(["ls-remote", "--heads", "origin"], path)
         branches: List[str] = []
         if branches_output:
-            for branch in branches_output.splitlines():
-                normalized = branch.strip()
+            for line in branches_output.splitlines():
+                parts = line.split()
+                if len(parts) < 2:
+                    continue
+                ref = parts[1].strip()
+                if not ref.startswith("refs/heads/"):
+                    continue
+                normalized = ref[len("refs/heads/") :]
                 if normalized and normalized not in branches:
                     branches.append(normalized)
 

--- a/backend/services.py
+++ b/backend/services.py
@@ -210,7 +210,13 @@ class GitMetadataService:
                     "error": err or f"Failed to switch from {active_branch or 'unknown'} to {selected_branch}.",
                 }
 
-        ok, out, err = self._run_git_with_result(["pull", "origin", selected_branch], path, timeout=30)
+        ok, out, err = self._run_git_with_result(
+            ["pull", "--no-write-fetch-head", "origin", selected_branch],
+            path,
+            timeout=30,
+        )
+        if not ok and err and "unknown option" in err.lower() and "write-fetch-head" in err.lower():
+            ok, out, err = self._run_git_with_result(["pull", "origin", selected_branch], path, timeout=30)
         if not ok:
             return {
                 "ok": False,

--- a/backend/services.py
+++ b/backend/services.py
@@ -178,16 +178,11 @@ class GitMetadataService:
 
     def list_active_branches(self, path: Path) -> dict:
         current_branch = self._run_git(["rev-parse", "--abbrev-ref", "HEAD"], path)
-        self._run_git(["fetch", "--prune", "origin"], path)
-        branches_output = self._run_git(["for-each-ref", "--format=%(refname:short)", "refs/remotes/origin"], path)
+        branches_output = self._run_git(["for-each-ref", "--format=%(refname:short)", "refs/heads"], path)
         branches: List[str] = []
         if branches_output:
             for branch in branches_output.splitlines():
                 normalized = branch.strip()
-                if not normalized or normalized == "origin/HEAD":
-                    continue
-                if normalized.startswith("origin/"):
-                    normalized = normalized[len("origin/") :]
                 if normalized and normalized not in branches:
                     branches.append(normalized)
 

--- a/backend/services.py
+++ b/backend/services.py
@@ -110,21 +110,30 @@ class DockerService:
 
 
 class GitMetadataService:
-    def _run_git(self, args: List[str], cwd: Path) -> Optional[str]:
+    def _run_git_with_result(self, args: List[str], cwd: Path, timeout: int = 8) -> Tuple[bool, Optional[str], Optional[str]]:
         try:
             result = subprocess.run(
                 ["git", "-c", f"safe.directory={cwd}", *args],
                 cwd=str(cwd),
                 capture_output=True,
                 text=True,
-                timeout=5,
+                timeout=timeout,
                 check=False,
             )
-            if result.returncode != 0:
-                return None
-            return result.stdout.strip() or None
-        except (subprocess.SubprocessError, FileNotFoundError):
+        except (subprocess.SubprocessError, FileNotFoundError) as exc:
+            return False, None, str(exc)
+
+        output = (result.stdout or "").strip() or None
+        error = (result.stderr or "").strip() or None
+        if result.returncode != 0:
+            return False, output, error
+        return True, output, error
+
+    def _run_git(self, args: List[str], cwd: Path) -> Optional[str]:
+        ok, output, _ = self._run_git_with_result(args, cwd, timeout=5)
+        if not ok:
             return None
+        return output
 
     def read_repo_metadata(self, path: Path) -> Tuple[Optional[str], Optional[str], Optional[str]]:
         remote = self._run_git(["remote", "get-url", "origin"], path)
@@ -165,6 +174,55 @@ class GitMetadataService:
             "ahead": ahead,
             "behind": behind,
             "status": status,
+        }
+
+    def list_active_branches(self, path: Path) -> dict:
+        current_branch = self._run_git(["rev-parse", "--abbrev-ref", "HEAD"], path)
+        self._run_git(["fetch", "--prune", "origin"], path)
+        branches_output = self._run_git(["for-each-ref", "--format=%(refname:short)", "refs/remotes/origin"], path)
+        branches: List[str] = []
+        if branches_output:
+            for branch in branches_output.splitlines():
+                normalized = branch.strip()
+                if not normalized or normalized == "origin/HEAD":
+                    continue
+                if normalized.startswith("origin/"):
+                    normalized = normalized[len("origin/") :]
+                if normalized and normalized not in branches:
+                    branches.append(normalized)
+
+        if current_branch and current_branch not in branches:
+            branches.insert(0, current_branch)
+
+        return {"currentBranch": current_branch, "branches": branches}
+
+    def pull_branch(self, path: Path, selected_branch: str) -> dict:
+        active_branch = self._run_git(["rev-parse", "--abbrev-ref", "HEAD"], path)
+        if not selected_branch:
+            return {"ok": False, "error": "No branch was selected."}
+
+        if active_branch != selected_branch:
+            ok, _, err = self._run_git_with_result(["switch", selected_branch], path)
+            if not ok:
+                return {
+                    "ok": False,
+                    "error": err or f"Failed to switch from {active_branch or 'unknown'} to {selected_branch}.",
+                }
+
+        ok, out, err = self._run_git_with_result(["pull", "origin", selected_branch], path, timeout=30)
+        if not ok:
+            return {
+                "ok": False,
+                "error": err or out or f"Failed to pull branch {selected_branch}.",
+            }
+
+        updated_branch = self._run_git(["rev-parse", "--abbrev-ref", "HEAD"], path)
+        updated_commit = self._run_git(["rev-parse", "HEAD"], path)
+        return {
+            "ok": True,
+            "branch": updated_branch,
+            "commit": updated_commit,
+            "output": out or "Already up to date.",
         }
 
 

--- a/frontend/pages/api/applications/[id]/branches.js
+++ b/frontend/pages/api/applications/[id]/branches.js
@@ -1,0 +1,37 @@
+import fs from 'fs';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  if (req.method !== 'GET') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { id } = req.query;
+  const port = process.env.BACKEND_PORT || '8000';
+  const devUrl = `http://localhost:${port}`;
+  const inDocker = fs.existsSync('/.dockerenv');
+  const backendUrl =
+    process.env.BACKEND_URL ||
+    (!inDocker && process.env.NODE_ENV === 'development' ? devUrl : 'http://backend:8000');
+
+  try {
+    const response = await fetch(`${backendUrl}/api/applications/${id}/branches`);
+    const text = await response.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { error: text };
+    }
+    res.status(response.status).json(data);
+  } catch (err) {
+    console.error('Proxy error:', err);
+    res.status(500).json({ error: 'Failed to fetch branches' });
+  }
+}

--- a/frontend/pages/api/applications/[id]/pull.js
+++ b/frontend/pages/api/applications/[id]/pull.js
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '../../auth/[...nextauth]';
+
+export default async function handler(req, res) {
+  const session = await getServerSession(req, res, authOptions);
+  if (!session) {
+    return res.status(401).json({ error: 'Unauthorized' });
+  }
+
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { id } = req.query;
+  const port = process.env.BACKEND_PORT || '8000';
+  const devUrl = `http://localhost:${port}`;
+  const inDocker = fs.existsSync('/.dockerenv');
+  const backendUrl =
+    process.env.BACKEND_URL ||
+    (!inDocker && process.env.NODE_ENV === 'development' ? devUrl : 'http://backend:8000');
+
+  try {
+    const response = await fetch(`${backendUrl}/api/applications/${id}/pull`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(req.body || {}),
+    });
+    const text = await response.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = { error: text };
+    }
+    res.status(response.status).json(data);
+  } catch (err) {
+    console.error('Proxy error:', err);
+    res.status(500).json({ error: 'Failed to pull branch' });
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -408,6 +408,39 @@ export default function Home() {
     }
   }, [fetchApplications, updateActionState]);
 
+  const fetchLogsForContainer = useCallback(async (id) => {
+    if (!id) return;
+    try {
+      const res = await fetch(`/api/containers/${id}/logs`);
+      if (!res.ok) {
+        let msg = res.statusText;
+        try {
+          const data = await res.json();
+          msg = data.error || JSON.stringify(data);
+        } catch {}
+        setLogState((prev) => ({ ...prev, error: msg, loading: false }));
+        return;
+      }
+      const data = await res.json();
+      setLogState((prev) => ({ ...prev, logs: data.logs || '', error: null, loading: false }));
+    } catch (err) {
+      setLogState((prev) => ({ ...prev, error: err.message, loading: false }));
+    }
+  }, []);
+
+  const showLogs = useCallback(async (id, name) => {
+    setLogState({ open: true, id, name, logs: '', error: null, loading: true });
+    fetchLogsForContainer(id);
+  }, [fetchLogsForContainer]);
+
+  const closeLogs = useCallback(() => {
+    if (logsIntervalRef.current) {
+      clearInterval(logsIntervalRef.current);
+      logsIntervalRef.current = null;
+    }
+    setLogState({ open: false, id: null, name: '', logs: '', error: null, loading: false });
+  }, []);
+
   useEffect(() => {
     const mapped = [];
     const generatedEdges = [];
@@ -497,38 +530,6 @@ export default function Home() {
   }, [actionState, applications, branchState, collapsedApps, fetchApplicationBranches, handleAction, handleDeleteImage, pullApplicationBranch, showLogs, toggleCollapse, updateBranchState]);
 
 
-  const fetchLogsForContainer = useCallback(async (id) => {
-    if (!id) return;
-    try {
-      const res = await fetch(`/api/containers/${id}/logs`);
-      if (!res.ok) {
-        let msg = res.statusText;
-        try {
-          const data = await res.json();
-          msg = data.error || JSON.stringify(data);
-        } catch {}
-        setLogState((prev) => ({ ...prev, error: msg, loading: false }));
-        return;
-      }
-      const data = await res.json();
-      setLogState((prev) => ({ ...prev, logs: data.logs || '', error: null, loading: false }));
-    } catch (err) {
-      setLogState((prev) => ({ ...prev, error: err.message, loading: false }));
-    }
-  }, []);
-
-  const showLogs = useCallback(async (id, name) => {
-    setLogState({ open: true, id, name, logs: '', error: null, loading: true });
-    fetchLogsForContainer(id);
-  }, [fetchLogsForContainer]);
-
-  const closeLogs = useCallback(() => {
-    if (logsIntervalRef.current) {
-      clearInterval(logsIntervalRef.current);
-      logsIntervalRef.current = null;
-    }
-    setLogState({ open: false, id: null, name: '', logs: '', error: null, loading: false });
-  }, []);
 
   useEffect(() => { fetchApplications(); }, [fetchApplications]);
 

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -85,7 +85,7 @@ function ApplicationNode({ data }) {
             )}
             {(data.gitBranch || data.gitCommit) && (
               <div className="text-[11px] text-yellow-100/90 mt-2">
-                {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}
+                Active: {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}
               </div>
             )}
             <div className="mt-2 flex items-center gap-1">
@@ -248,6 +248,7 @@ export default function Home() {
   const [highlightedContainerId, setHighlightedContainerId] = useState(null);
   const highlightTimeoutRef = useRef(null);
   const logsIntervalRef = useRef(null);
+  const loadedBranchesRef = useRef(new Set());
 
   const updateActionState = useCallback((id, newState) => {
     setActionState((prev) => ({ ...prev, [id]: { ...prev[id], ...newState } }));
@@ -257,7 +258,12 @@ export default function Home() {
     setBranchState((prev) => ({ ...prev, [id]: { ...prev[id], ...newState } }));
   }, []);
 
-  const fetchApplicationBranches = useCallback(async (appId) => {
+  const fetchApplicationBranches = useCallback(async (appId, options = {}) => {
+    const force = !!options.force;
+    if (!force && loadedBranchesRef.current.has(appId)) {
+      return null;
+    }
+
     updateBranchState(appId, { loading: true, error: null });
     try {
       const response = await fetch(`/api/applications/${appId}/branches`);
@@ -267,6 +273,7 @@ export default function Home() {
       }
       const branches = Array.isArray(payload?.branches) ? payload.branches : [];
       const currentBranch = payload?.currentBranch || null;
+      loadedBranchesRef.current.add(appId);
       updateBranchState(appId, {
         loading: false,
         error: null,
@@ -289,97 +296,10 @@ export default function Home() {
       const res = await fetch('/api/applications');
       const data = await res.json();
       setApplications(data);
-
-      const mapped = [];
-      const generatedEdges = [];
-      let currentY = 40;
-
-      data.forEach((app) => {
-        const appContainers = app.containers || [];
-        const collapsed = !!collapsedApps[app.id];
-        const containerCount = appContainers.length;
-
-        const calculatedWidth = Math.max(
-          APP_MIN_WIDTH,
-          GROUP_PADDING * 2 + Math.max(1, containerCount) * NODE_WIDTH + Math.max(0, containerCount - 1) * HORIZONTAL_GAP
-        );
-
-        let appHeight = APP_HEADER_HEIGHT + 12;
-        if (!collapsed && containerCount > 0) {
-          let tallestContainer = BASE_NODE_HEIGHT;
-          appContainers.forEach((container) => {
-            tallestContainer = Math.max(tallestContainer, estimateNodeHeight(container));
-          });
-          appHeight = APP_HEADER_HEIGHT + GROUP_PADDING + tallestContainer + GROUP_PADDING;
-        }
-
-        mapped.push({
-          id: `app-${app.id}`,
-          type: 'application',
-          position: { x: 40, y: currentY },
-          data: {
-            ...app,
-            collapsed,
-            containerCount,
-            width: calculatedWidth,
-            height: appHeight,
-            availableBranches: branchState[app.id]?.branches || (app.gitBranch ? [app.gitBranch] : []),
-            selectedBranch: branchState[app.id]?.selectedBranch || app.gitBranch || '',
-            branchLoading: !!branchState[app.id]?.loading,
-            branchPulling: !!branchState[app.id]?.pulling,
-            branchError: branchState[app.id]?.error || null,
-            onBranchChange: (branch) => updateBranchState(app.id, { selectedBranch: branch, error: null }),
-            onRefreshBranches: () => fetchApplicationBranches(app.id),
-            applicationId: app.id,
-            onPullBranch: pullApplicationBranch,
-            onToggleCollapse: () => toggleCollapse(app.id),
-          },
-          draggable: false,
-          selectable: true,
-        });
-
-        if (!collapsed) {
-          appContainers.forEach((c, i) => {
-            mapped.push({
-              id: c.id,
-              type: 'container',
-              position: {
-                x: 40 + GROUP_PADDING + i * (NODE_WIDTH + HORIZONTAL_GAP),
-                y: currentY + APP_HEADER_HEIGHT + GROUP_PADDING,
-              },
-              data: {
-                ...c,
-                containerId: c.id,
-                onRestart: () => handleAction(c.id, 'restart'),
-                onStop: () => handleAction(c.id, 'stop'),
-                onShowLogs: () => showLogs(c.id, c.name),
-                onDeleteImage: () => handleDeleteImage(c.id),
-                loadingAction: actionState[c.id]?.loadingAction,
-                error: actionState[c.id]?.error,
-              },
-            });
-          });
-
-          for (let i = 0; i < appContainers.length - 1; i++) {
-            generatedEdges.push({
-              id: `${appContainers[i].id}-${appContainers[i + 1].id}`,
-              source: appContainers[i].id,
-              target: appContainers[i + 1].id,
-              style: { stroke: '#ffd500' },
-            });
-          }
-        }
-
-        currentY += appHeight + ROW_VERTICAL_GAP;
-      });
-
-      setNodes(mapped);
-      setEdges(generatedEdges);
     } catch (err) {
       console.error(err);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [actionState, branchState, collapsedApps, fetchApplicationBranches, toggleCollapse, updateBranchState]);
+  }, []);
 
   const allContainers = useMemo(() => applications.flatMap((app) => app.containers || []), [applications]);
 
@@ -442,7 +362,7 @@ export default function Home() {
           : app
       )));
       fetchApplications();
-      fetchApplicationBranches(appId);
+      fetchApplicationBranches(appId, { force: true });
     } catch (err) {
       updateBranchState(appId, { pulling: false, error: err.message || 'Failed to pull branch.' });
     }
@@ -488,6 +408,95 @@ export default function Home() {
     }
   }, [fetchApplications, updateActionState]);
 
+  useEffect(() => {
+    const mapped = [];
+    const generatedEdges = [];
+    let currentY = 40;
+
+    applications.forEach((app) => {
+      const appContainers = app.containers || [];
+      const collapsed = !!collapsedApps[app.id];
+      const containerCount = appContainers.length;
+
+      const calculatedWidth = Math.max(
+        APP_MIN_WIDTH,
+        GROUP_PADDING * 2 + Math.max(1, containerCount) * NODE_WIDTH + Math.max(0, containerCount - 1) * HORIZONTAL_GAP
+      );
+
+      let appHeight = APP_HEADER_HEIGHT + 12;
+      if (!collapsed && containerCount > 0) {
+        let tallestContainer = BASE_NODE_HEIGHT;
+        appContainers.forEach((container) => {
+          tallestContainer = Math.max(tallestContainer, estimateNodeHeight(container));
+        });
+        appHeight = APP_HEADER_HEIGHT + GROUP_PADDING + tallestContainer + GROUP_PADDING;
+      }
+
+      mapped.push({
+        id: `app-${app.id}`,
+        type: 'application',
+        position: { x: 40, y: currentY },
+        data: {
+          ...app,
+          collapsed,
+          containerCount,
+          width: calculatedWidth,
+          height: appHeight,
+          availableBranches: branchState[app.id]?.branches || (app.gitBranch ? [app.gitBranch] : []),
+          selectedBranch: branchState[app.id]?.selectedBranch || app.gitBranch || '',
+          branchLoading: !!branchState[app.id]?.loading,
+          branchPulling: !!branchState[app.id]?.pulling,
+          branchError: branchState[app.id]?.error || null,
+          onBranchChange: (branch) => updateBranchState(app.id, { selectedBranch: branch, error: null }),
+          onRefreshBranches: () => fetchApplicationBranches(app.id, { force: true }),
+          applicationId: app.id,
+          onPullBranch: pullApplicationBranch,
+          onToggleCollapse: () => toggleCollapse(app.id),
+        },
+        draggable: false,
+        selectable: true,
+      });
+
+      if (!collapsed) {
+        appContainers.forEach((c, i) => {
+          mapped.push({
+            id: c.id,
+            type: 'container',
+            position: {
+              x: 40 + GROUP_PADDING + i * (NODE_WIDTH + HORIZONTAL_GAP),
+              y: currentY + APP_HEADER_HEIGHT + GROUP_PADDING,
+            },
+            data: {
+              ...c,
+              containerId: c.id,
+              onRestart: () => handleAction(c.id, 'restart'),
+              onStop: () => handleAction(c.id, 'stop'),
+              onShowLogs: () => showLogs(c.id, c.name),
+              onDeleteImage: () => handleDeleteImage(c.id),
+              loadingAction: actionState[c.id]?.loadingAction,
+              error: actionState[c.id]?.error,
+            },
+          });
+        });
+
+        for (let i = 0; i < appContainers.length - 1; i++) {
+          generatedEdges.push({
+            id: `${appContainers[i].id}-${appContainers[i + 1].id}`,
+            source: appContainers[i].id,
+            target: appContainers[i + 1].id,
+            style: { stroke: '#ffd500' },
+          });
+        }
+      }
+
+      currentY += appHeight + ROW_VERTICAL_GAP;
+    });
+
+    setNodes(mapped);
+    setEdges(generatedEdges);
+  }, [actionState, applications, branchState, collapsedApps, fetchApplicationBranches, handleAction, handleDeleteImage, pullApplicationBranch, showLogs, toggleCollapse, updateBranchState]);
+
+
   const fetchLogsForContainer = useCallback(async (id) => {
     if (!id) return;
     try {
@@ -525,10 +534,9 @@ export default function Home() {
 
   useEffect(() => {
     applications.forEach((app) => {
-      if (branchState[app.id]?.branches?.length) return;
       fetchApplicationBranches(app.id);
     });
-  }, [applications, branchState, fetchApplicationBranches]);
+  }, [applications, fetchApplicationBranches]);
 
   useEffect(() => {
     if (!logState.open || !logState.id) {

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -224,7 +224,7 @@ const BASE_NODE_HEIGHT = 240;
 const PORT_LINE_HEIGHT = 18;
 const PORT_SECTION_PADDING = 12;
 const ROW_VERTICAL_GAP = 40;
-const APP_HEADER_HEIGHT = 120;
+const APP_HEADER_HEIGHT = 156;
 const NODE_WIDTH = 192;
 const HORIZONTAL_GAP = 28;
 const GROUP_PADDING = 20;
@@ -456,7 +456,7 @@ export default function Home() {
         GROUP_PADDING * 2 + Math.max(1, containerCount) * NODE_WIDTH + Math.max(0, containerCount - 1) * HORIZONTAL_GAP
       );
 
-      let appHeight = APP_HEADER_HEIGHT + 12;
+      let appHeight = APP_HEADER_HEIGHT + GROUP_PADDING;
       if (!collapsed && containerCount > 0) {
         let tallestContainer = BASE_NODE_HEIGHT;
         appContainers.forEach((container) => {

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -88,6 +88,47 @@ function ApplicationNode({ data }) {
                 {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}
               </div>
             )}
+            <div className="mt-2 flex items-center gap-1">
+              <select
+                value={data.selectedBranch || ''}
+                onChange={(event) => data.onBranchChange?.(event.target.value)}
+                className="nodrag nopan bg-black border border-yellow-400 text-yellow-100 text-[11px] rounded px-2 py-1 min-w-0 flex-1"
+                title="Select branch"
+              >
+                {(data.availableBranches || []).map((branch) => (
+                  <option key={branch} value={branch}>{branch}</option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onMouseDown={handleCollapseMouseDown}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  data.onRefreshBranches?.();
+                }}
+                className="nodrag nopan text-black bg-yellow-500 hover:bg-yellow-400 rounded px-2 py-1 text-[11px]"
+                disabled={data.branchLoading}
+                title="Refresh branches"
+              >
+                {data.branchLoading ? '…' : '↻'}
+              </button>
+              <button
+                type="button"
+                onMouseDown={handleCollapseMouseDown}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  data.onPullBranch?.(data.applicationId);
+                }}
+                className="nodrag nopan text-black bg-yellow-500 hover:bg-yellow-400 rounded px-2 py-1 text-[11px]"
+                disabled={data.branchPulling || !data.selectedBranch}
+                title="Git pull selected branch"
+              >
+                {data.branchPulling ? 'Pull…' : 'Pull'}
+              </button>
+            </div>
+            {data.branchError && <div className="text-red-400 text-[11px] mt-1 break-words">{data.branchError}</div>}
           </div>
           <div className="flex items-start gap-2">
             <UsagePie label="CPU" sharePercent={data.resourceUsage?.sharePercent || 0} />
@@ -201,6 +242,7 @@ export default function Home() {
   const [applications, setApplications] = useState([]);
   const [collapsedApps, setCollapsedApps] = useState({});
   const [actionState, setActionState] = useState({});
+  const [branchState, setBranchState] = useState({});
   const [logState, setLogState] = useState({ open: false, id: null, name: '', logs: '', error: null, loading: false });
   const [reactFlowInstance, setReactFlowInstance] = useState(null);
   const [highlightedContainerId, setHighlightedContainerId] = useState(null);
@@ -210,6 +252,33 @@ export default function Home() {
   const updateActionState = useCallback((id, newState) => {
     setActionState((prev) => ({ ...prev, [id]: { ...prev[id], ...newState } }));
   }, []);
+
+  const updateBranchState = useCallback((id, newState) => {
+    setBranchState((prev) => ({ ...prev, [id]: { ...prev[id], ...newState } }));
+  }, []);
+
+  const fetchApplicationBranches = useCallback(async (appId) => {
+    updateBranchState(appId, { loading: true, error: null });
+    try {
+      const response = await fetch(`/api/applications/${appId}/branches`);
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload?.detail || payload?.error || response.statusText);
+      }
+      const branches = Array.isArray(payload?.branches) ? payload.branches : [];
+      const currentBranch = payload?.currentBranch || null;
+      updateBranchState(appId, {
+        loading: false,
+        error: null,
+        branches,
+        selectedBranch: currentBranch || branches[0] || '',
+      });
+      return { branches, currentBranch };
+    } catch (err) {
+      updateBranchState(appId, { loading: false, error: err.message || 'Failed to load branches.' });
+      return null;
+    }
+  }, [updateBranchState]);
 
   const toggleCollapse = useCallback((appId) => {
     setCollapsedApps((prev) => ({ ...prev, [appId]: !prev[appId] }));
@@ -254,6 +323,15 @@ export default function Home() {
             containerCount,
             width: calculatedWidth,
             height: appHeight,
+            availableBranches: branchState[app.id]?.branches || (app.gitBranch ? [app.gitBranch] : []),
+            selectedBranch: branchState[app.id]?.selectedBranch || app.gitBranch || '',
+            branchLoading: !!branchState[app.id]?.loading,
+            branchPulling: !!branchState[app.id]?.pulling,
+            branchError: branchState[app.id]?.error || null,
+            onBranchChange: (branch) => updateBranchState(app.id, { selectedBranch: branch, error: null }),
+            onRefreshBranches: () => fetchApplicationBranches(app.id),
+            applicationId: app.id,
+            onPullBranch: pullApplicationBranch,
             onToggleCollapse: () => toggleCollapse(app.id),
           },
           draggable: false,
@@ -301,7 +379,7 @@ export default function Home() {
       console.error(err);
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [actionState, collapsedApps, toggleCollapse]);
+  }, [actionState, branchState, collapsedApps, fetchApplicationBranches, toggleCollapse, updateBranchState]);
 
   const allContainers = useMemo(() => applications.flatMap((app) => app.containers || []), [applications]);
 
@@ -334,6 +412,41 @@ export default function Home() {
     setHighlightedContainerId(containerId);
     highlightTimeoutRef.current = setTimeout(() => setHighlightedContainerId(null), 2000);
   }, [allContainers, nodes, reactFlowInstance]);
+
+  const pullApplicationBranch = useCallback(async (appId) => {
+    const selectedBranch = branchState[appId]?.selectedBranch;
+    if (!selectedBranch) {
+      updateBranchState(appId, { error: 'Select a branch before pulling.' });
+      return;
+    }
+    updateBranchState(appId, { pulling: true, error: null });
+    try {
+      const response = await fetch(`/api/applications/${appId}/pull`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ branch: selectedBranch }),
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload?.detail || payload?.error || response.statusText);
+      }
+
+      updateBranchState(appId, {
+        pulling: false,
+        error: null,
+        selectedBranch: payload?.branch || selectedBranch,
+      });
+      setApplications((prev) => prev.map((app) => (
+        app.id === appId
+          ? { ...app, gitBranch: payload?.branch || app.gitBranch, gitCommit: payload?.commit || app.gitCommit }
+          : app
+      )));
+      fetchApplications();
+      fetchApplicationBranches(appId);
+    } catch (err) {
+      updateBranchState(appId, { pulling: false, error: err.message || 'Failed to pull branch.' });
+    }
+  }, [branchState, fetchApplicationBranches, fetchApplications, updateBranchState]);
 
   const handleAction = useCallback(async (id, action) => {
     updateActionState(id, { loadingAction: action, error: null });
@@ -409,6 +522,13 @@ export default function Home() {
   }, []);
 
   useEffect(() => { fetchApplications(); }, [fetchApplications]);
+
+  useEffect(() => {
+    applications.forEach((app) => {
+      if (branchState[app.id]?.branches?.length) return;
+      fetchApplicationBranches(app.id);
+    });
+  }, [applications, branchState, fetchApplicationBranches]);
 
   useEffect(() => {
     if (!logState.open || !logState.id) {


### PR DESCRIPTION
### Motivation
- Provide an in-UI control per project to inspect and change the repository branch without reloading the page. 
- Allow operators to refresh branch lists and run a `git pull` for a selected branch from the dashboard with clear error feedback. 
- Surface git switch/pull errors (e.g. uncommitted changes blocking switch) inline so users can act on failures quickly.

### Description
- Backend: added a safer git runner and helpers in `GitMetadataService` (`_run_git_with_result`, `list_active_branches`, `pull_branch`) to list remote branches and perform `switch + pull` with detailed error output. 
- Backend: added API endpoints `GET /api/applications/{id}/branches` and `POST /api/applications/{id}/pull` which call the new git helpers and return readable errors when operations fail. 
- Frontend proxy routes: added authenticated Next.js proxy endpoints `frontend/pages/api/applications/[id]/branches.js` and `.../pull.js` that forward requests to the backend. 
- Frontend UI: replaced the branch/commit row in each project card with a branch `select` dropdown, a refresh (`↻`) button and a `Pull` button, added per-application branch state (`branchState`), `fetchApplicationBranches`, and `pullApplicationBranch` logic so branch lists auto-load, default to the VPS active branch, can be refreshed in-place and can run pull flows that update the UI and surface red inline errors. 

### Testing
- Ran `python -m compileall backend` and it completed successfully. 
- Installed frontend deps with `npm install` and ran `npm run lint`, which completed and reported only an existing Next.js `<img>` lint warning. 
- Started the Next.js dev server (`npm run dev -- --hostname 0.0.0.0 --port 3000`) for a visual smoke-check and captured a screenshot to validate the UI changes. 
- Verified the app-level flows by exercising the branch list and pull endpoints via the new frontend proxies (manual verification during the dev run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bd1921b4c832caefabaa6aec4b103)