### PR TITLE
Add nginx domain discovery and quick-open domain buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ When a match is found, the app card shows one or more 🌐 buttons that open the
 
 Domains are grouped in the UI as:
 - **Sites via Docker** (matched by `proxy_pass` host port), and
-- **Sites estáticos (Nginx root/alias)** (matched only by static `root`/`alias` path).
+- **Sites estáticos (Nginx root/alias)** (matched by static `root`/`alias` path, with fallback by domain name hint when no `proxy_pass` exists in that server block).
 
 ### Scanner config
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,15 @@ An app is detected when a folder has at least one of:
 
 `docker-compose.yml` already mounts these host paths read-only into the backend container so discovery works on VPS.
 
+### Domain/subdomain detection (Nginx)
+
+The backend also scans `/etc/nginx` (mounted read-only) and tries to map `server_name` entries to each detected application by:
+
+- matching `root`/`alias` paths that are inside the repository path;
+- matching `proxy_pass` host ports against the app's published Docker ports.
+
+When a match is found, the app card shows one or more 🌐 buttons that open the detected domain in a new tab.
+
 ### Scanner config
 
 `backend/config.yml`:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,6 @@ An app is detected when a folder has at least one of:
 
 The backend also scans `/etc/nginx` (mounted read-only) and tries to map `server_name` entries to each detected application by:
 
-- matching `root`/`alias` paths that are inside the repository path;
 - matching `proxy_pass` host ports against the app's published Docker ports.
 
 Matching is done **per `server { ... }` block** (not across the whole file), to avoid leaking domains from unrelated virtual hosts in the same config file.
@@ -115,8 +114,7 @@ Matching is done **per `server { ... }` block** (not across the whole file), to 
 When a match is found, the app card shows one or more 🌐 buttons that open the detected domain in a new tab. Hovering the button shows the config source file and match strategy.
 
 Domains are grouped in the UI as:
-- **Sites via Docker** (matched by `proxy_pass` host port), and
-- **Sites estáticos (Nginx root/alias)** (matched by static `root`/`alias` path, with fallback by domain name hint when no `proxy_pass` exists in that server block).
+- **Sites via Docker** (matched by `proxy_pass` host port).
 
 ### Scanner config
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ The backend also scans `/etc/nginx` (mounted read-only) and tries to map `server
 - matching `root`/`alias` paths that are inside the repository path;
 - matching `proxy_pass` host ports against the app's published Docker ports.
 
-When a match is found, the app card shows one or more 🌐 buttons that open the detected domain in a new tab.
+Matching is done **per `server { ... }` block** (not across the whole file), to avoid leaking domains from unrelated virtual hosts in the same config file.
+
+When a match is found, the app card shows one or more 🌐 buttons that open the detected domain in a new tab. Hovering the button shows the config source file and match strategy.
 
 ### Scanner config
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,10 @@ Matching is done **per `server { ... }` block** (not across the whole file), to 
 
 When a match is found, the app card shows one or more 🌐 buttons that open the detected domain in a new tab. Hovering the button shows the config source file and match strategy.
 
+Domains are grouped in the UI as:
+- **Sites via Docker** (matched by `proxy_pass` host port), and
+- **Sites estáticos (Nginx root/alias)** (matched only by static `root`/`alias` path).
+
 ### Scanner config
 
 `backend/config.yml`:

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ from services import (
     ApplicationRegistry,
     ContainerAssociationService,
     DockerService,
+    DomainDiscoveryService,
     GitMetadataService,
 )
 
@@ -28,6 +29,7 @@ git_metadata_service = GitMetadataService()
 app_discovery_service = ApplicationDiscoveryService(git_metadata_service)
 association_service = ContainerAssociationService()
 aggregation_service = ApplicationAggregationService()
+domain_discovery_service = DomainDiscoveryService()
 application_registry = ApplicationRegistry()
 app_config = load_application_config()
 
@@ -51,16 +53,19 @@ async def run_application_scan():
     applications = await asyncio.to_thread(app_discovery_service.discover, app_config.scan_paths)
     containers = await asyncio.to_thread(docker_service.list_containers_for_association)
     associations = association_service.associate(applications, containers)
-    aggregated = aggregation_service.aggregate(applications, associations)
+    domains_by_app = await asyncio.to_thread(domain_discovery_service.discover, applications, associations)
+    aggregated = aggregation_service.aggregate(applications, associations, domains_by_app)
     await application_registry.set_applications(aggregated)
 
     assigned_count = sum(len(associations.get(app.id, [])) for app in applications)
     unassigned_count = len(associations.get("unassigned", []))
+    matched_domains = sum(len(domains_by_app.get(app.id, [])) for app in applications)
     logger.info(
-        "scan_complete applications=%s assigned_containers=%s unassigned_containers=%s",
+        "scan_complete applications=%s assigned_containers=%s unassigned_containers=%s domains=%s",
         len(applications),
         assigned_count,
         unassigned_count,
+        matched_domains,
     )
 
 

--- a/backend/services.py
+++ b/backend/services.py
@@ -423,14 +423,25 @@ class DomainDiscoveryService:
 
     def _extract_domains_from_server_name(self, value: str) -> List[str]:
         domains = []
+        seen = set()
         for candidate in value.split():
-            host = candidate.strip()
+            host = candidate.strip().lower()
             if not host or host in {"_", "default_server"}:
                 continue
             if host.startswith("$") or host.startswith("~") or "*" in host:
                 continue
+            if host in seen:
+                continue
+            seen.add(host)
             domains.append(host)
-        return domains
+
+        filtered = []
+        domain_set = set(domains)
+        for host in domains:
+            if host.startswith("www.") and host[4:] in domain_set:
+                continue
+            filtered.append(host)
+        return filtered
 
     def _extract_proxy_port(self, proxy_url: str) -> Optional[str]:
         match = re.search(r":(\d+)(?:/|$)", proxy_url)

--- a/backend/services.py
+++ b/backend/services.py
@@ -381,6 +381,7 @@ class ApplicationDiscoveryService:
 
 
 class DomainDiscoveryService:
+    SERVER_BLOCK_RE = re.compile(r"\bserver\s*\{", re.IGNORECASE)
     SERVER_NAME_RE = re.compile(r"\bserver_name\s+([^;]+);", re.IGNORECASE)
     ROOT_RE = re.compile(r"\b(?:root|alias)\s+([^;]+);", re.IGNORECASE)
     PROXY_PASS_RE = re.compile(r"\bproxy_pass\s+(https?://[^;]+);", re.IGNORECASE)
@@ -398,6 +399,27 @@ class DomainDiscoveryService:
             if path.suffix == ".conf" or path.parent.name in {"sites-enabled", "sites-available", "conf.d"}:
                 files.append(path)
         return files
+
+    def _extract_server_blocks(self, content: str) -> List[str]:
+        blocks = []
+        for match in self.SERVER_BLOCK_RE.finditer(content):
+            open_brace_idx = content.find("{", match.start())
+            if open_brace_idx == -1:
+                continue
+            depth = 0
+            end_idx = None
+            for idx in range(open_brace_idx, len(content)):
+                char = content[idx]
+                if char == "{":
+                    depth += 1
+                elif char == "}":
+                    depth -= 1
+                    if depth == 0:
+                        end_idx = idx
+                        break
+            if end_idx is not None:
+                blocks.append(content[open_brace_idx + 1 : end_idx])
+        return blocks
 
     def _extract_domains_from_server_name(self, value: str) -> List[str]:
         domains = []
@@ -440,50 +462,52 @@ class DomainDiscoveryService:
             except OSError:
                 continue
 
-            server_names = []
-            for match in self.SERVER_NAME_RE.finditer(content):
-                server_names.extend(self._extract_domains_from_server_name(match.group(1)))
-            if not server_names:
-                continue
-
-            root_paths = []
-            for match in self.ROOT_RE.finditer(content):
-                raw_path = match.group(1).strip().strip('"\'')
-                if raw_path and not raw_path.startswith("$"):
-                    root_paths.append(str(Path(raw_path).resolve()))
-
-            proxy_ports = []
-            for match in self.PROXY_PASS_RE.finditer(content):
-                port = self._extract_proxy_port(match.group(1))
-                if port:
-                    proxy_ports.append(port)
-
-            matching_apps = set()
-            for root_path in root_paths:
-                for app_path, app_id in by_path:
-                    if root_path == app_path or root_path.startswith(f"{app_path}/"):
-                        matching_apps.add(app_id)
-                        break
-
-            for app in applications:
-                if not app_ports.get(app.id):
+            for server_block in self._extract_server_blocks(content):
+                server_names = []
+                for match in self.SERVER_NAME_RE.finditer(server_block):
+                    server_names.extend(self._extract_domains_from_server_name(match.group(1)))
+                if not server_names:
                     continue
-                if any(port in app_ports[app.id] for port in proxy_ports):
-                    matching_apps.add(app.id)
 
-            for app_id in matching_apps:
-                for domain in server_names:
-                    key = (app_id, domain)
-                    if key in seen:
+                root_paths = []
+                for match in self.ROOT_RE.finditer(server_block):
+                    raw_path = match.group(1).strip().strip("\"'")
+                    if raw_path and not raw_path.startswith("$"):
+                        root_paths.append(str(Path(raw_path).resolve()))
+
+                proxy_ports = []
+                for match in self.PROXY_PASS_RE.finditer(server_block):
+                    port = self._extract_proxy_port(match.group(1))
+                    if port:
+                        proxy_ports.append(port)
+
+                match_reasons_by_app: Dict[str, set] = {}
+                for root_path in root_paths:
+                    for app_path, app_id in by_path:
+                        if root_path == app_path or root_path.startswith(f"{app_path}/"):
+                            match_reasons_by_app.setdefault(app_id, set()).add("path")
+                            break
+
+                for app in applications:
+                    if not app_ports.get(app.id):
                         continue
-                    seen.add(key)
-                    domains_by_app[app_id].append(
-                        {
-                            "domain": domain,
-                            "url": f"https://{domain}",
-                            "source": str(conf_path),
-                        }
-                    )
+                    if any(port in app_ports[app.id] for port in proxy_ports):
+                        match_reasons_by_app.setdefault(app.id, set()).add("proxy_port")
+
+                for app_id, reasons in match_reasons_by_app.items():
+                    for domain in server_names:
+                        key = (app_id, domain)
+                        if key in seen:
+                            continue
+                        seen.add(key)
+                        domains_by_app[app_id].append(
+                            {
+                                "domain": domain,
+                                "url": f"https://{domain}",
+                                "source": str(conf_path),
+                                "matchReasons": sorted(reasons),
+                            }
+                        )
 
         return domains_by_app
 

--- a/backend/services.py
+++ b/backend/services.py
@@ -383,7 +383,6 @@ class ApplicationDiscoveryService:
 class DomainDiscoveryService:
     SERVER_BLOCK_RE = re.compile(r"\bserver\s*\{", re.IGNORECASE)
     SERVER_NAME_RE = re.compile(r"\bserver_name\s+([^;]+);", re.IGNORECASE)
-    ROOT_RE = re.compile(r"\b(?:root|alias)\s+([^;]+);", re.IGNORECASE)
     PROXY_PASS_RE = re.compile(r"\bproxy_pass\s+(https?://[^;]+);", re.IGNORECASE)
 
     def __init__(self, nginx_root: str = "/etc/nginx"):
@@ -447,32 +446,7 @@ class DomainDiscoveryService:
         match = re.search(r":(\d+)(?:/|$)", proxy_url)
         return match.group(1) if match else None
 
-    def _domain_matches_app_name(self, domain: str, app: Application) -> bool:
-        app_tokens = set()
-        app_name = (app.name or '').strip().lower()
-        folder_name = Path(app.path).name.strip().lower() if app.path else ''
-        if app_name:
-            app_tokens.add(app_name)
-        if folder_name:
-            app_tokens.add(folder_name)
-
-        host = (domain or '').strip().lower()
-        if not host:
-            return False
-        host = host.removeprefix('www.')
-        first_label = host.split('.', 1)[0]
-        if not first_label:
-            return False
-
-        return any(token and (first_label == token or first_label.startswith(f"{token}-")) for token in app_tokens)
-
     def discover(self, applications: List[Application], associations: Dict[str, List[dict]]) -> Dict[str, List[dict]]:
-        by_path = sorted(
-            ((str(Path(app.path).resolve()), app.id) for app in applications if app.path),
-            key=lambda item: len(item[0]),
-            reverse=True,
-        )
-
         app_ports: Dict[str, set] = {}
         for app in applications:
             ports = set()
@@ -499,12 +473,6 @@ class DomainDiscoveryService:
                 if not server_names:
                     continue
 
-                root_paths = []
-                for match in self.ROOT_RE.finditer(server_block):
-                    raw_path = match.group(1).strip().strip("\"'")
-                    if raw_path and not raw_path.startswith("$"):
-                        root_paths.append(str(Path(raw_path).resolve()))
-
                 proxy_ports = []
                 for match in self.PROXY_PASS_RE.finditer(server_block):
                     port = self._extract_proxy_port(match.group(1))
@@ -512,23 +480,12 @@ class DomainDiscoveryService:
                         proxy_ports.append(port)
 
                 match_reasons_by_app: Dict[str, set] = {}
-                for root_path in root_paths:
-                    for app_path, app_id in by_path:
-                        if root_path == app_path or root_path.startswith(f"{app_path}/"):
-                            match_reasons_by_app.setdefault(app_id, set()).add("path")
-                            break
 
                 for app in applications:
                     if not app_ports.get(app.id):
                         continue
                     if any(port in app_ports[app.id] for port in proxy_ports):
                         match_reasons_by_app.setdefault(app.id, set()).add("proxy_port")
-
-                # Static fallback: when there is no proxy_pass match, map by clear domain hint (e.g. kairos.example.com -> app kairos)
-                if not proxy_ports:
-                    for app in applications:
-                        if any(self._domain_matches_app_name(domain, app) for domain in server_names):
-                            match_reasons_by_app.setdefault(app.id, set()).add("domain_hint")
 
                 for app_id, reasons in match_reasons_by_app.items():
                     for domain in server_names:
@@ -537,14 +494,13 @@ class DomainDiscoveryService:
                             continue
                         seen.add(key)
                         reason_list = sorted(reasons)
-                        domain_type = "docker" if "proxy_port" in reasons else "static"
                         domains_by_app[app_id].append(
                             {
                                 "domain": domain,
                                 "url": f"https://{domain}",
                                 "source": str(conf_path),
                                 "matchReasons": reason_list,
-                                "domainType": domain_type,
+                                "domainType": "docker",
                             }
                         )
 

--- a/backend/services.py
+++ b/backend/services.py
@@ -511,12 +511,15 @@ class DomainDiscoveryService:
                         if key in seen:
                             continue
                         seen.add(key)
+                        reason_list = sorted(reasons)
+                        domain_type = "docker" if "proxy_port" in reasons else "static"
                         domains_by_app[app_id].append(
                             {
                                 "domain": domain,
                                 "url": f"https://{domain}",
                                 "source": str(conf_path),
-                                "matchReasons": sorted(reasons),
+                                "matchReasons": reason_list,
+                                "domainType": domain_type,
                             }
                         )
 

--- a/backend/services.py
+++ b/backend/services.py
@@ -447,6 +447,25 @@ class DomainDiscoveryService:
         match = re.search(r":(\d+)(?:/|$)", proxy_url)
         return match.group(1) if match else None
 
+    def _domain_matches_app_name(self, domain: str, app: Application) -> bool:
+        app_tokens = set()
+        app_name = (app.name or '').strip().lower()
+        folder_name = Path(app.path).name.strip().lower() if app.path else ''
+        if app_name:
+            app_tokens.add(app_name)
+        if folder_name:
+            app_tokens.add(folder_name)
+
+        host = (domain or '').strip().lower()
+        if not host:
+            return False
+        host = host.removeprefix('www.')
+        first_label = host.split('.', 1)[0]
+        if not first_label:
+            return False
+
+        return any(token and (first_label == token or first_label.startswith(f"{token}-")) for token in app_tokens)
+
     def discover(self, applications: List[Application], associations: Dict[str, List[dict]]) -> Dict[str, List[dict]]:
         by_path = sorted(
             ((str(Path(app.path).resolve()), app.id) for app in applications if app.path),
@@ -504,6 +523,12 @@ class DomainDiscoveryService:
                         continue
                     if any(port in app_ports[app.id] for port in proxy_ports):
                         match_reasons_by_app.setdefault(app.id, set()).add("proxy_port")
+
+                # Static fallback: when there is no proxy_pass match, map by clear domain hint (e.g. kairos.example.com -> app kairos)
+                if not proxy_ports:
+                    for app in applications:
+                        if any(self._domain_matches_app_name(domain, app) for domain in server_names):
+                            match_reasons_by_app.setdefault(app.id, set()).add("domain_hint")
 
                 for app_id, reasons in match_reasons_by_app.items():
                     for domain in server_names:

--- a/backend/services.py
+++ b/backend/services.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import os
+import re
 import subprocess
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -22,6 +23,7 @@ class Application:
     description: Optional[str]
     summary: Optional[str]
     containers: List[dict]
+    domains: List[dict]
     lastScanTimestamp: str
 
 
@@ -370,11 +372,120 @@ class ApplicationDiscoveryService:
                         description=description,
                         summary=summary,
                         containers=[],
+                        domains=[],
                         lastScanTimestamp=now,
                     )
                 )
                 dirs[:] = []
         return discovered
+
+
+class DomainDiscoveryService:
+    SERVER_NAME_RE = re.compile(r"\bserver_name\s+([^;]+);", re.IGNORECASE)
+    ROOT_RE = re.compile(r"\b(?:root|alias)\s+([^;]+);", re.IGNORECASE)
+    PROXY_PASS_RE = re.compile(r"\bproxy_pass\s+(https?://[^;]+);", re.IGNORECASE)
+
+    def __init__(self, nginx_root: str = "/etc/nginx"):
+        self.nginx_root = Path(nginx_root)
+
+    def _iter_nginx_configs(self):
+        if not self.nginx_root.exists() or not self.nginx_root.is_dir():
+            return []
+        files = []
+        for path in self.nginx_root.rglob("*"):
+            if not path.is_file():
+                continue
+            if path.suffix == ".conf" or path.parent.name in {"sites-enabled", "sites-available", "conf.d"}:
+                files.append(path)
+        return files
+
+    def _extract_domains_from_server_name(self, value: str) -> List[str]:
+        domains = []
+        for candidate in value.split():
+            host = candidate.strip()
+            if not host or host in {"_", "default_server"}:
+                continue
+            if host.startswith("$") or host.startswith("~") or "*" in host:
+                continue
+            domains.append(host)
+        return domains
+
+    def _extract_proxy_port(self, proxy_url: str) -> Optional[str]:
+        match = re.search(r":(\d+)(?:/|$)", proxy_url)
+        return match.group(1) if match else None
+
+    def discover(self, applications: List[Application], associations: Dict[str, List[dict]]) -> Dict[str, List[dict]]:
+        by_path = sorted(
+            ((str(Path(app.path).resolve()), app.id) for app in applications if app.path),
+            key=lambda item: len(item[0]),
+            reverse=True,
+        )
+
+        app_ports: Dict[str, set] = {}
+        for app in applications:
+            ports = set()
+            for container in associations.get(app.id, []):
+                for port in container.get("ports") or []:
+                    host_port = str(port.get("host_port") or "").strip()
+                    if host_port:
+                        ports.add(host_port)
+            app_ports[app.id] = ports
+
+        domains_by_app: Dict[str, List[dict]] = {app.id: [] for app in applications}
+        seen = set()
+
+        for conf_path in self._iter_nginx_configs():
+            try:
+                content = conf_path.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+
+            server_names = []
+            for match in self.SERVER_NAME_RE.finditer(content):
+                server_names.extend(self._extract_domains_from_server_name(match.group(1)))
+            if not server_names:
+                continue
+
+            root_paths = []
+            for match in self.ROOT_RE.finditer(content):
+                raw_path = match.group(1).strip().strip('"\'')
+                if raw_path and not raw_path.startswith("$"):
+                    root_paths.append(str(Path(raw_path).resolve()))
+
+            proxy_ports = []
+            for match in self.PROXY_PASS_RE.finditer(content):
+                port = self._extract_proxy_port(match.group(1))
+                if port:
+                    proxy_ports.append(port)
+
+            matching_apps = set()
+            for root_path in root_paths:
+                for app_path, app_id in by_path:
+                    if root_path == app_path or root_path.startswith(f"{app_path}/"):
+                        matching_apps.add(app_id)
+                        break
+
+            for app in applications:
+                if not app_ports.get(app.id):
+                    continue
+                if any(port in app_ports[app.id] for port in proxy_ports):
+                    matching_apps.add(app.id)
+
+            for app_id in matching_apps:
+                for domain in server_names:
+                    key = (app_id, domain)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    domains_by_app[app_id].append(
+                        {
+                            "domain": domain,
+                            "url": f"https://{domain}",
+                            "source": str(conf_path),
+                        }
+                    )
+
+        return domains_by_app
 
 
 class ContainerAssociationService:
@@ -447,10 +558,16 @@ class ApplicationAggregationService:
         }
         return app_data
 
-    def aggregate(self, applications: List[Application], associations: Dict[str, List[dict]]) -> List[dict]:
+    def aggregate(
+        self,
+        applications: List[Application],
+        associations: Dict[str, List[dict]],
+        domains_by_app: Optional[Dict[str, List[dict]]] = None,
+    ) -> List[dict]:
         payload = []
         for app in applications:
             app.containers = associations.get(app.id, [])
+            app.domains = (domains_by_app or {}).get(app.id, [])
             payload.append(self._with_usage(asdict(app)))
 
         unassigned = self._with_usage(
@@ -464,6 +581,7 @@ class ApplicationAggregationService:
                 "description": None,
                 "summary": None,
                 "containers": associations.get("unassigned", []),
+                "domains": [],
                 "lastScanTimestamp": datetime.now(timezone.utc).isoformat(),
             }
         )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - /opt:/opt
       - /srv:/srv
       - /var/www:/var/www
+      - /etc/nginx:/etc/nginx:ro
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
     ports:
       - "${BACKEND_PORT:-8000}:8000"

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -91,6 +91,7 @@ function ApplicationNode({ data }) {
                   const href = entry?.url || (entry?.domain ? `https://${entry.domain}` : null);
                   const label = entry?.domain || entry?.url;
                   if (!href || !label) return null;
+                  const sourcePath = entry?.source || 'origem não identificada';
                   const reasons = Array.isArray(entry?.matchReasons) && entry.matchReasons.length > 0
                     ? `Match: ${entry.matchReasons.join(', ')}`
                     : null;
@@ -101,16 +102,21 @@ function ApplicationNode({ data }) {
                     source,
                   ].filter(Boolean).join('\n');
                   return (
-                    <a
-                      key={`${data.id}-${label}`}
-                      href={href}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="inline-flex items-center rounded border border-yellow-300/70 px-2 py-0.5 text-[10px] text-yellow-100 hover:bg-yellow-400/20"
-                      title={details}
-                    >
-                      🌐 {label}
-                    </a>
+                    <span key={`${data.id}-${label}`} className="relative inline-flex group">
+                      <a
+                        href={href}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center rounded border border-yellow-300/70 px-2 py-0.5 text-[10px] text-yellow-100 hover:bg-yellow-400/20"
+                        title={details}
+                      >
+                        🌐 {label}
+                      </a>
+                      <span className="pointer-events-none absolute left-0 top-full z-20 mt-1 hidden min-w-[260px] max-w-[420px] rounded border border-yellow-500/70 bg-black px-2 py-1 text-[10px] leading-snug text-yellow-100 shadow-lg group-hover:block">
+                        <span className="block text-yellow-300">Arquivo de origem</span>
+                        <span className="block break-all">{sourcePath}</span>
+                      </span>
+                    </span>
                   );
                 })}
               </div>

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -87,59 +87,46 @@ function ApplicationNode({ data }) {
 
             {Array.isArray(data.domains) && data.domains.length > 0 && (() => {
               const dockerDomains = data.domains.filter((entry) => entry?.domainType === 'docker');
-              const staticDomains = data.domains.filter((entry) => entry?.domainType !== 'docker');
-              const renderDomainButtons = (entries) => (
-                <div className="mt-1 flex flex-wrap gap-1">
-                  {entries.map((entry) => {
-                    const href = entry?.url || (entry?.domain ? `https://${entry.domain}` : null);
-                    const label = entry?.domain || entry?.url;
-                    if (!href || !label) return null;
-                    const sourcePath = entry?.source || 'origem não identificada';
-                    const reasons = Array.isArray(entry?.matchReasons) && entry.matchReasons.length > 0
-                      ? `Match: ${entry.matchReasons.join(', ')}`
-                      : null;
-                    const source = entry?.source ? `Source: ${entry.source}` : null;
-                    const details = [
-                      `Open ${label}`,
-                      reasons,
-                      source,
-                    ].filter(Boolean).join('\n');
-                    return (
-                      <span key={`${data.id}-${label}`} className="relative inline-flex group">
-                        <a
-                          href={href}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="inline-flex items-center rounded border border-yellow-300/70 px-2 py-0.5 text-[10px] text-yellow-100 hover:bg-yellow-400/20"
-                          title={details}
-                        >
-                          🌐 {label}
-                        </a>
-                        <span className="pointer-events-none absolute left-0 top-full z-20 mt-1 hidden min-w-[260px] max-w-[420px] rounded border border-yellow-500/70 bg-black px-2 py-1 text-[10px] leading-snug text-yellow-100 shadow-lg group-hover:block">
-                          <span className="block text-yellow-300">Arquivo de origem</span>
-                          <span className="block break-all">{sourcePath}</span>
-                        </span>
-                      </span>
-                    );
-                  })}
-                </div>
-              );
+              if (dockerDomains.length === 0) return null;
 
               return (
-                <div className="mt-2 space-y-2">
-                  {dockerDomains.length > 0 && (
-                    <fieldset className="rounded border border-yellow-400/40 px-2 py-1">
-                      <legend className="px-1 text-[10px] text-yellow-300 uppercase tracking-wide">Sites via Docker</legend>
-                      {renderDomainButtons(dockerDomains)}
-                    </fieldset>
-                  )}
-                  {staticDomains.length > 0 && (
-                    <fieldset className="rounded border border-yellow-400/40 px-2 py-1">
-                      <legend className="px-1 text-[10px] text-yellow-300 uppercase tracking-wide">Sites estáticos (Nginx root/alias)</legend>
-                      {renderDomainButtons(staticDomains)}
-                    </fieldset>
-                  )}
-                </div>
+                <fieldset className="mt-2 rounded border border-yellow-400/40 px-2 py-1">
+                  <legend className="px-1 text-[10px] text-yellow-300 uppercase tracking-wide">Sites via Docker</legend>
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {dockerDomains.map((entry) => {
+                      const href = entry?.url || (entry?.domain ? `https://${entry.domain}` : null);
+                      const label = entry?.domain || entry?.url;
+                      if (!href || !label) return null;
+                      const sourcePath = entry?.source || 'origem não identificada';
+                      const reasons = Array.isArray(entry?.matchReasons) && entry.matchReasons.length > 0
+                        ? `Match: ${entry.matchReasons.join(', ')}`
+                        : null;
+                      const source = entry?.source ? `Source: ${entry.source}` : null;
+                      const details = [
+                        `Open ${label}`,
+                        reasons,
+                        source,
+                      ].filter(Boolean).join('\n');
+                      return (
+                        <span key={`${data.id}-${label}`} className="relative inline-flex group">
+                          <a
+                            href={href}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="inline-flex items-center rounded border border-yellow-300/70 px-2 py-0.5 text-[10px] text-yellow-100 hover:bg-yellow-400/20"
+                            title={details}
+                          >
+                            🌐 {label}
+                          </a>
+                          <span className="pointer-events-none absolute left-0 top-full z-20 mt-1 hidden min-w-[260px] max-w-[420px] rounded border border-yellow-500/70 bg-black px-2 py-1 text-[10px] leading-snug text-yellow-100 shadow-lg group-hover:block">
+                            <span className="block text-yellow-300">Arquivo de origem</span>
+                            <span className="block break-all">{sourcePath}</span>
+                          </span>
+                        </span>
+                      );
+                    })}
+                  </div>
+                </fieldset>
               );
             })()}
             {(data.gitBranch || data.gitCommit) && (

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -91,6 +91,15 @@ function ApplicationNode({ data }) {
                   const href = entry?.url || (entry?.domain ? `https://${entry.domain}` : null);
                   const label = entry?.domain || entry?.url;
                   if (!href || !label) return null;
+                  const reasons = Array.isArray(entry?.matchReasons) && entry.matchReasons.length > 0
+                    ? `Match: ${entry.matchReasons.join(', ')}`
+                    : null;
+                  const source = entry?.source ? `Source: ${entry.source}` : null;
+                  const details = [
+                    `Open ${label}`,
+                    reasons,
+                    source,
+                  ].filter(Boolean).join('\n');
                   return (
                     <a
                       key={`${data.id}-${label}`}
@@ -98,7 +107,7 @@ function ApplicationNode({ data }) {
                       target="_blank"
                       rel="noreferrer"
                       className="inline-flex items-center rounded border border-yellow-300/70 px-2 py-0.5 text-[10px] text-yellow-100 hover:bg-yellow-400/20"
-                      title={`Open ${label}`}
+                      title={details}
                     >
                       🌐 {label}
                     </a>

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -84,6 +84,28 @@ function ApplicationNode({ data }) {
             ) : (
               <div className="text-[11px] text-yellow-200/70 mt-1">Repository remote unavailable</div>
             )}
+
+            {Array.isArray(data.domains) && data.domains.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-1">
+                {data.domains.map((entry) => {
+                  const href = entry?.url || (entry?.domain ? `https://${entry.domain}` : null);
+                  const label = entry?.domain || entry?.url;
+                  if (!href || !label) return null;
+                  return (
+                    <a
+                      key={`${data.id}-${label}`}
+                      href={href}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="inline-flex items-center rounded border border-yellow-300/70 px-2 py-0.5 text-[10px] text-yellow-100 hover:bg-yellow-400/20"
+                      title={`Open ${label}`}
+                    >
+                      🌐 {label}
+                    </a>
+                  );
+                })}
+              </div>
+            )}
             {(data.gitBranch || data.gitCommit) && (
               <div className="text-[11px] text-yellow-100/90 mt-2">
                 {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -85,42 +85,63 @@ function ApplicationNode({ data }) {
               <div className="text-[11px] text-yellow-200/70 mt-1">Repository remote unavailable</div>
             )}
 
-            {Array.isArray(data.domains) && data.domains.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-1">
-                {data.domains.map((entry) => {
-                  const href = entry?.url || (entry?.domain ? `https://${entry.domain}` : null);
-                  const label = entry?.domain || entry?.url;
-                  if (!href || !label) return null;
-                  const sourcePath = entry?.source || 'origem não identificada';
-                  const reasons = Array.isArray(entry?.matchReasons) && entry.matchReasons.length > 0
-                    ? `Match: ${entry.matchReasons.join(', ')}`
-                    : null;
-                  const source = entry?.source ? `Source: ${entry.source}` : null;
-                  const details = [
-                    `Open ${label}`,
-                    reasons,
-                    source,
-                  ].filter(Boolean).join('\n');
-                  return (
-                    <span key={`${data.id}-${label}`} className="relative inline-flex group">
-                      <a
-                        href={href}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="inline-flex items-center rounded border border-yellow-300/70 px-2 py-0.5 text-[10px] text-yellow-100 hover:bg-yellow-400/20"
-                        title={details}
-                      >
-                        🌐 {label}
-                      </a>
-                      <span className="pointer-events-none absolute left-0 top-full z-20 mt-1 hidden min-w-[260px] max-w-[420px] rounded border border-yellow-500/70 bg-black px-2 py-1 text-[10px] leading-snug text-yellow-100 shadow-lg group-hover:block">
-                        <span className="block text-yellow-300">Arquivo de origem</span>
-                        <span className="block break-all">{sourcePath}</span>
+            {Array.isArray(data.domains) && data.domains.length > 0 && (() => {
+              const dockerDomains = data.domains.filter((entry) => entry?.domainType === 'docker');
+              const staticDomains = data.domains.filter((entry) => entry?.domainType !== 'docker');
+              const renderDomainButtons = (entries) => (
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {entries.map((entry) => {
+                    const href = entry?.url || (entry?.domain ? `https://${entry.domain}` : null);
+                    const label = entry?.domain || entry?.url;
+                    if (!href || !label) return null;
+                    const sourcePath = entry?.source || 'origem não identificada';
+                    const reasons = Array.isArray(entry?.matchReasons) && entry.matchReasons.length > 0
+                      ? `Match: ${entry.matchReasons.join(', ')}`
+                      : null;
+                    const source = entry?.source ? `Source: ${entry.source}` : null;
+                    const details = [
+                      `Open ${label}`,
+                      reasons,
+                      source,
+                    ].filter(Boolean).join('\n');
+                    return (
+                      <span key={`${data.id}-${label}`} className="relative inline-flex group">
+                        <a
+                          href={href}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center rounded border border-yellow-300/70 px-2 py-0.5 text-[10px] text-yellow-100 hover:bg-yellow-400/20"
+                          title={details}
+                        >
+                          🌐 {label}
+                        </a>
+                        <span className="pointer-events-none absolute left-0 top-full z-20 mt-1 hidden min-w-[260px] max-w-[420px] rounded border border-yellow-500/70 bg-black px-2 py-1 text-[10px] leading-snug text-yellow-100 shadow-lg group-hover:block">
+                          <span className="block text-yellow-300">Arquivo de origem</span>
+                          <span className="block break-all">{sourcePath}</span>
+                        </span>
                       </span>
-                    </span>
-                  );
-                })}
-              </div>
-            )}
+                    );
+                  })}
+                </div>
+              );
+
+              return (
+                <div className="mt-2 space-y-2">
+                  {dockerDomains.length > 0 && (
+                    <fieldset className="rounded border border-yellow-400/40 px-2 py-1">
+                      <legend className="px-1 text-[10px] text-yellow-300 uppercase tracking-wide">Sites via Docker</legend>
+                      {renderDomainButtons(dockerDomains)}
+                    </fieldset>
+                  )}
+                  {staticDomains.length > 0 && (
+                    <fieldset className="rounded border border-yellow-400/40 px-2 py-1">
+                      <legend className="px-1 text-[10px] text-yellow-300 uppercase tracking-wide">Sites estáticos (Nginx root/alias)</legend>
+                      {renderDomainButtons(staticDomains)}
+                    </fieldset>
+                  )}
+                </div>
+              );
+            })()}
             {(data.gitBranch || data.gitCommit) && (
               <div className="text-[11px] text-yellow-100/90 mt-2">
                 {data.gitBranch || 'unknown'} {data.gitCommit ? `• ${data.gitCommit.slice(0, 8)}` : ''}


### PR DESCRIPTION
### Motivation

- Provide automatic mapping from Nginx-hosted domains/subdomains to discovered applications so the dashboard can quickly open running sites.
- Make domain discovery work inside Docker Compose by exposing Nginx configuration files to the backend container.

### Description

- Add `DomainDiscoveryService` in `backend/services.py` that scans `/etc/nginx` config files, extracts `server_name`, `root`/`alias`, and `proxy_pass`, and matches domains to applications by filesystem root/path or by proxy target port.
- Include a `domains` field on `Application` objects and include discovered domains in the aggregated `/api/applications` payload via the updated `ApplicationAggregationService`.
- Integrate domain discovery into the main scan loop in `backend/main.py` and add a log entry reporting matched domains per scan.
- Show detected domains on each application card in the UI (`frontend/pages/index.js`) as clickable 🌐 buttons that open the site in a new tab, and mount `/etc/nginx` read-only into the backend in `docker-compose.yml` so discovery works in Compose environments.
- Document Nginx domain/subdomain detection behavior in `README.md`.

### Testing

- Ran `python -m compileall backend` and it completed successfully.
- Ran `cd frontend && npm run lint` which completed successfully with the project’s existing ESLint warning about `<img>` usage but no blocking errors.
- Attempted a headless browser screenshot with the Playwright tooling which failed due to the environment (Chromium crash / SIGSEGV), unrelated to the application logic and not required for CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fa48e1808832ca2cc2eeffe5e82de)