### PR TITLE
Handle compose start 504 timeout without false error

### DIFF
--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -601,6 +601,25 @@ export default function Home({ vpsDefaults = {} }) {
       await fetchApplications();
       await refreshBranches(appId, data?.branch || selectedBranch);
     } catch (err) {
+      const errorMessage = err?.message || '';
+      const composeTimedOut = action === 'start' && /504\s+Gateway\s+Time-?out/i.test(errorMessage);
+
+      if (composeTimedOut) {
+        setGitUiState((prev) => ({
+          ...prev,
+          [appId]: {
+            ...(prev[appId] || {}),
+            composeLoading: null,
+            gitError: null,
+          },
+        }));
+        await fetchApplications();
+        setTimeout(() => {
+          fetchApplications();
+        }, 2500);
+        return;
+      }
+
       setGitUiState((prev) => ({
         ...prev,
         [appId]: {


### PR DESCRIPTION
### Motivation
- Prevent showing a false error when a `docker compose up` completes on the server but the HTTP request times out with `504 Gateway Time-out` through a proxy, which left container cards stale in the UI.

### Description
- In `frontend/pages/index.js` inside `runComposeAction` catch handler, detect a `504 Gateway Time-?out` message for `action === 'start'` and treat it as a transient timeout by clearing `composeLoading` and `gitError` and not surfacing an error.
- Trigger an immediate `fetchApplications()` and a second delayed `fetchApplications()` (2.5s) so the UI refreshes and shows the correct container status without a full page reload, while preserving normal error handling for other cases.

### Testing
- No automated tests were run per request.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3adb883b4832ca40c80ab7b0fac17)